### PR TITLE
import a selection of sample patches from RHEL AI downstream build

### DIFF
--- a/overrides/patches/aotriton-0.4.1b0/0001-0.4.1b-use-host-pip.patch
+++ b/overrides/patches/aotriton-0.4.1b0/0001-0.4.1b-use-host-pip.patch
@@ -1,0 +1,66 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fbc4717..5010b8d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -75,18 +75,18 @@ set(ENV{VIRTUAL_ENV} "${VENV_DIR}")
+ # unset(Python3_EXECUTABLE)
+ # find_package(Python3 COMPONENTS Interpreter REQUIRED)
+ 
+-execute_process(COMMAND ${CMAKE_COMMAND} -E env VIRTUAL_ENV=${VENV_DIR} PATH="${VENV_DIR}/bin:$ENV{PATH}" python -m site --user-site OUTPUT_VARIABLE VENV_SITE)
++execute_process(COMMAND ${CMAKE_COMMAND} -E env VIRTUAL_ENV=${VENV_DIR} PATH="/usr/bin:$ENV{PATH}" python -m site --user-site OUTPUT_VARIABLE VENV_SITE)
+ message("VENV_SITE ${VENV_SITE}")
+ 
+ add_custom_target(aotriton_venv_req
+-  COMMAND ${CMAKE_COMMAND} -E env VIRTUAL_ENV=${VENV_DIR} PATH="${VENV_DIR}/bin:$ENV{PATH}" python -m pip install -r "${CMAKE_CURRENT_LIST_DIR}/requirements.txt"
++  COMMAND ${CMAKE_COMMAND} -E env VIRTUAL_ENV=${VENV_DIR} PATH="/usr/bin:$ENV{PATH}" python -m pip install -r "${CMAKE_CURRENT_LIST_DIR}/requirements.txt"
+   BYPRODUCTS "${VENV_DIR}/bin/pytest"
+ )
+ 
+ set(TRITON_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/triton_build")
+ execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory "${TRITON_BUILD_DIR}")
+ add_custom_target(aotriton_venv_triton
+-  COMMAND ${CMAKE_COMMAND} -E env VIRTUAL_ENV=${VENV_DIR} PATH="${VENV_DIR}/bin:$ENV{PATH}" TRITON_BUILD_DIR=${TRITON_BUILD_DIR} python setup.py develop
++  COMMAND ${CMAKE_COMMAND} -E env VIRTUAL_ENV=${VENV_DIR} PATH="/usr/bin:$ENV{PATH}" TRITON_BUILD_DIR=${TRITON_BUILD_DIR} python setup.py develop
+   # COMMAND ${CMAKE_COMMAND} -E env VIRTUAL_ENV=${VENV_DIR} python -m pip show triton
+   WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/third_party/triton/python/"
+   BYPRODUCTS "${VENV_SITE}/triton/_C/libtriton.so"
+diff --git a/v2src/CMakeLists.txt b/v2src/CMakeLists.txt
+index cd941b6..e38d295 100644
+--- a/v2src/CMakeLists.txt
++++ b/v2src/CMakeLists.txt
+@@ -12,7 +12,7 @@ if(AOTRITON_COMPRESS_KERNEL)
+   list(APPEND AOTRITON_GEN_FLAGS "--enable_zstd" "${ZSTD_EXEC}")
+ endif(AOTRITON_COMPRESS_KERNEL)
+ add_custom_target(aotriton_v2_gen_compile
+-  COMMAND ${CMAKE_COMMAND} -E env VIRTUAL_ENV=${VENV_DIR} PATH="${VENV_DIR}/bin:$ENV{PATH}" python -m v2python.generate_compile --target_gpus ${TARGET_GPUS} --build_dir "${AOTRITON_V2_BUILD_DIR}" ${AOTRITON_GEN_FLAGS}
++  COMMAND ${CMAKE_COMMAND} -E env VIRTUAL_ENV=${VENV_DIR} PATH="/usr/bin:$ENV{PATH}" python -m v2python.generate_compile --target_gpus ${TARGET_GPUS} --build_dir "${AOTRITON_V2_BUILD_DIR}" ${AOTRITON_GEN_FLAGS}
+   WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+   BYPRODUCTS "${AOTRITON_V2_BUILD_DIR}/Makefile.compile"
+ )
+@@ -30,7 +30,7 @@ endif()
+ add_custom_target(aotriton_v2_compile
+   # (CAVEAT) KNOWN PROBLEM: Will not work if LD_PRELOAD is not empty
+   # FIXME: Change this into `-E env --modify LD_PRELOAD=path_list_prepend:${AMDOCL_LD_PRELOAD}` when minimal cmake >= 3.25
+-  COMMAND ${CMAKE_COMMAND} -E env VIRTUAL_ENV=${VENV_DIR} PATH="${VENV_DIR}/bin:$ENV{PATH}" make -j ${MAX_JOBS} -f Makefile.compile LIBHSA_RUNTIME64=${AMDHSA_LD_PRELOAD}
++  COMMAND ${CMAKE_COMMAND} -E env VIRTUAL_ENV=${VENV_DIR} PATH="/usr/bin:$ENV{PATH}" make -j ${MAX_JOBS} -f Makefile.compile LIBHSA_RUNTIME64=${AMDHSA_LD_PRELOAD}
+   WORKING_DIRECTORY "${AOTRITON_V2_BUILD_DIR}"
+   COMMAND_EXPAND_LISTS
+   BYPRODUCTS "${AOTRITON_V2_BUILD_DIR}/flash/attn_fwd.h"
+@@ -50,7 +50,7 @@ message(STATUS "AOTRITON_ZSTD_INCLUDE ${AOTRITON_ZSTD_INCLUDE}")
+ message(STATUS "AOTRITON_SHIM_FLAGS ${AOTRITON_SHIM_FLAGS}")
+ 
+ add_custom_target(aotriton_v2_gen_shim
+-  COMMAND ${CMAKE_COMMAND} -E env VIRTUAL_ENV=${VENV_DIR} PATH="${VENV_DIR}/bin:$ENV{PATH}" python -m v2python.generate_shim --target_gpus ${TARGET_GPUS} --build_dir ${AOTRITON_V2_BUILD_DIR} ${AOTRITON_SHIM_FLAGS}
++  COMMAND ${CMAKE_COMMAND} -E env VIRTUAL_ENV=${VENV_DIR} PATH="/usr/bin:$ENV{PATH}" python -m v2python.generate_shim --target_gpus ${TARGET_GPUS} --build_dir ${AOTRITON_V2_BUILD_DIR} ${AOTRITON_SHIM_FLAGS}
+   WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+   COMMAND_EXPAND_LISTS
+   BYPRODUCTS "${AOTRITON_V2_BUILD_DIR}/Makefile.shim"
+@@ -60,7 +60,7 @@ add_dependencies(aotriton_v2_gen_shim aotriton_v2_compile) # Shim source files n
+ message(STATUS "AOTRITON_EXTRA_COMPILER_OPTIONS ${AOTRITON_EXTRA_COMPILER_OPTIONS}")
+ add_custom_target(aotriton_v2
+   ALL
+-  COMMAND ${CMAKE_COMMAND} -E env VIRTUAL_ENV=${VENV_DIR} PATH="${VENV_DIR}/bin:$ENV{PATH}" make -j ${MAX_JOBS} -f Makefile.shim HIPCC=${AOTRITON_HIPCC_PATH} AR=${CMAKE_AR} EXTRA_COMPILER_OPTIONS=${AOTRITON_EXTRA_COMPILER_OPTIONS}
++  COMMAND ${CMAKE_COMMAND} -E env VIRTUAL_ENV=${VENV_DIR} PATH="/usr/bin:$ENV{PATH}" make -j ${MAX_JOBS} -f Makefile.shim HIPCC=${AOTRITON_HIPCC_PATH} AR=${CMAKE_AR} EXTRA_COMPILER_OPTIONS=${AOTRITON_EXTRA_COMPILER_OPTIONS}
+   WORKING_DIRECTORY "${AOTRITON_V2_BUILD_DIR}"
+   BYPRODUCTS "${AOTRITON_V2_BUILD_DIR}/libaotriton_v2.a"
+ )

--- a/overrides/patches/aotriton-0.4.1b0/0002-0.4.1b-triton-use-git-packages.patch
+++ b/overrides/patches/aotriton-0.4.1b0/0002-0.4.1b-triton-use-git-packages.patch
@@ -1,0 +1,94 @@
+diff --git a/third_party/triton/python/setup.py b/third_party/triton/python/setup.py
+index 55425adf1c90..661fd7167110 100644
+--- a/third_party/triton/python/setup.py
++++ b/third_party/triton/python/setup.py
+@@ -1,5 +1,6 @@
+ import os
+ import platform
++import pybind11
+ import re
+ import shutil
+ import subprocess
+@@ -47,80 +48,9 @@ def get_codegen_backends():
+ # --- third party packages -----
+ 
+ 
+-class Package(NamedTuple):
+-    package: str
+-    name: str
+-    url: str
+-    include_flag: str
+-    lib_flag: str
+-    syspath_var_name: str
+-
+-
+-# pybind11
+-
+-
+-def get_pybind11_package_info():
+-    name = "pybind11-2.11.1"
+-    url = "https://github.com/pybind/pybind11/archive/refs/tags/v2.11.1.tar.gz"
+-    return Package("pybind11", name, url, "PYBIND11_INCLUDE_DIR", "", "PYBIND11_SYSPATH")
+-
+-
+-# llvm
+-
+-
+-def get_llvm_package_info():
+-    # added statement for Apple Silicon
+-    system = platform.system()
+-    arch = platform.machine()
+-    if arch == 'aarch64':
+-        arch = 'arm64'
+-    if system == "Darwin":
+-        arch = platform.machine()
+-        if arch == "x86_64":
+-            arch = "x64"
+-        system_suffix = f"macos-{arch}"
+-    elif system == "Linux":
+-        # TODO: arm64
+-        vglibc = tuple(map(int, platform.libc_ver()[1].split('.')))
+-        vglibc = vglibc[0] * 100 + vglibc[1]
+-        system_suffix = 'ubuntu-x64' if vglibc > 217 else 'centos-x64'
+-    else:
+-        return Package("llvm", "LLVM-C.lib", "", "LLVM_INCLUDE_DIRS", "LLVM_LIBRARY_DIR", "LLVM_SYSPATH")
+-    # use_assert_enabled_llvm = check_env_flag("TRITON_USE_ASSERT_ENABLED_LLVM", "False")
+-    # release_suffix = "assert" if use_assert_enabled_llvm else "release"
+-    rev = "49af6502"
+-    name = f"llvm-{rev}-{system_suffix}"
+-    url = f"https://tritonlang.blob.core.windows.net/llvm-builds/{name}.tar.gz"
+-    return Package("llvm", name, url, "LLVM_INCLUDE_DIRS", "LLVM_LIBRARY_DIR", "LLVM_SYSPATH")
+-
+-
+ def get_thirdparty_packages(triton_cache_path):
+-    packages = [get_pybind11_package_info(), get_llvm_package_info()]
+-    thirdparty_cmake_args = []
+-    for p in packages:
+-        package_root_dir = os.path.join(triton_cache_path, p.package)
+-        package_dir = os.path.join(package_root_dir, p.name)
+-        if p.syspath_var_name in os.environ:
+-            package_dir = os.environ[p.syspath_var_name]
+-        version_file_path = os.path.join(package_dir, "version.txt")
+-        if p.syspath_var_name not in os.environ and\
+-           (not os.path.exists(version_file_path) or Path(version_file_path).read_text() != p.url):
+-            try:
+-                shutil.rmtree(package_root_dir)
+-            except Exception:
+-                pass
+-            os.makedirs(package_root_dir, exist_ok=True)
+-            print(f'downloading and extracting {p.url} ...')
+-            ftpstream = urllib.request.urlopen(p.url)
+-            file = tarfile.open(fileobj=ftpstream, mode="r|*")
+-            file.extractall(path=package_root_dir)
+-            # write version url to package_dir
+-            with open(os.path.join(package_dir, "version.txt"), "w") as f:
+-                f.write(p.url)
+-        if p.include_flag:
+-            thirdparty_cmake_args.append(f"-D{p.include_flag}={package_dir}/include")
+-        if p.lib_flag:
+-            thirdparty_cmake_args.append(f"-D{p.lib_flag}={package_dir}/lib")
++    llvm_syspath = os.environ["LLVM_SYSPATH"]
++    thirdparty_cmake_args = [f"-DPYBIND11_INCLUDE_DIR={pybind11.get_include()}", f"-DLLVM_INCLUDE_DIRS={llvm_syspath}/include", f"-DLLVM_LIBRARY_DIR={llvm_syspath}/lib"]
+     return thirdparty_cmake_args
+ 
+ 

--- a/overrides/patches/aotriton-0.4.1b0/0003-0.4.1b-drop-testing.patch
+++ b/overrides/patches/aotriton-0.4.1b0/0003-0.4.1b-drop-testing.patch
@@ -1,0 +1,10 @@
+diff --git a/third_party/triton/CMakeLists.txt b/third_party/triton/CMakeLists.txt
+index 55a5d8b3b727..c302661cc84d 100644
+--- a/third_party/triton/CMakeLists.txt
++++ b/third_party/triton/CMakeLists.txt
+@@ -309,5 +309,3 @@ if (${CODEGEN_BACKENDS_LEN} GREATER 0)
+ endif()
+ 
+ add_subdirectory(test)
+-
+-add_subdirectory(unittest)

--- a/overrides/patches/aotriton-0.6b0/0001-Override-venv-python-directory.patch
+++ b/overrides/patches/aotriton-0.6b0/0001-Override-venv-python-directory.patch
@@ -1,0 +1,91 @@
+From ba293cdca5de7495260a501027dc7e51434df6e9 Mon Sep 17 00:00:00 2001
+From: Joseph Groenenboom <jgroenen@redhat.com>
+Date: Mon, 30 Sep 2024 10:43:35 -0400
+Subject: [PATCH 1/1] Override venv python directory.
+
+Remove use of venv to make use of our own consolodated build and complier hosting.
+
+---
+ CMakeLists.txt       |  6 +++---
+ v2src/CMakeLists.txt | 10 +++++-----
+ 2 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4d93610..81f1ec2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -74,11 +74,11 @@ message("VENV_DIR ${VENV_DIR}")
+ # unset(Python3_EXECUTABLE)
+ # find_package(Python3 COMPONENTS Interpreter REQUIRED)
+ 
+-execute_process(COMMAND ${CMAKE_COMMAND} -E env VIRTUAL_ENV=${VENV_DIR} "${VENV_DIR}/bin/python" -c "import site; print(site.getsitepackages()[0], end='')" OUTPUT_VARIABLE VENV_SITE)
++execute_process(COMMAND ${CMAKE_COMMAND} -E env VIRTUAL_ENV=${VENV_DIR} PATH="/usr/bin:$ENV{PATH}" python -c "import site; print(site.getsitepackages()[0], end='')" OUTPUT_VARIABLE VENV_SITE)
+ # string(STRIP "${VENV_SITE}" VENV_SITE)
+ message("VENV_SITE ${VENV_SITE}")
+ 
+-execute_process(COMMAND ${CMAKE_COMMAND} -E env VIRTUAL_ENV=${VENV_DIR} "${VENV_DIR}/bin/python" -m pip install -r "${CMAKE_CURRENT_LIST_DIR}/requirements.txt")
++execute_process(COMMAND ${CMAKE_COMMAND} -E env VIRTUAL_ENV=${VENV_DIR} PATH="/usr/bin:$ENV{PATH}" python -m pip install -r "${CMAKE_CURRENT_LIST_DIR}/requirements.txt")
+ 
+ set(TRITON_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/triton_build")
+ execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory "${TRITON_BUILD_DIR}")
+@@ -87,7 +87,7 @@ set(AOTRITON_TRITON_EGGLINK "${VENV_SITE}/triton.egg-link")
+ message("AOTRITON_TRITON_EGGLINK ${AOTRITON_TRITON_EGGLINK}")
+ 
+ add_custom_command(OUTPUT "${AOTRITON_TRITON_EGGLINK}"
+-  COMMAND ${CMAKE_COMMAND} -E env VIRTUAL_ENV=${VENV_DIR} TRITON_BUILD_DIR=${TRITON_BUILD_DIR} "${VENV_DIR}/bin/python" setup.py develop
++  COMMAND ${CMAKE_COMMAND} -E env VIRTUAL_ENV=${VENV_DIR} TRITON_BUILD_DIR=${TRITON_BUILD_DIR} PATH="/usr/bin:$ENV{PATH}" python setup.py develop
+   # COMMAND ${CMAKE_COMMAND} -E env VIRTUAL_ENV=${VENV_DIR} python -m pip show triton
+   WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/third_party/triton/python/"
+   BYPRODUCTS "${AOTRITON_TRITON_SO}"
+diff --git a/v2src/CMakeLists.txt b/v2src/CMakeLists.txt
+index f0d323f..f4753dc 100644
+--- a/v2src/CMakeLists.txt
++++ b/v2src/CMakeLists.txt
+@@ -26,7 +26,7 @@ message("AOTRITON_COMPILER ${AOTRITON_COMPILER}")
+ # add_dependencies(aotriton_v2_gen_compile aotriton_venv_triton)
+ 
+ execute_process(
+-  COMMAND ${CMAKE_COMMAND} -E env VIRTUAL_ENV=${VENV_DIR} "${VENV_DIR}/bin/python" -m v2python.generate_compile --target_gpus ${TARGET_GPUS} --build_dir "${AOTRITON_V2_BUILD_DIR}" --bare_mode
++  COMMAND ${CMAKE_COMMAND} -E env VIRTUAL_ENV=${VENV_DIR} PATH="/usr/bin:$ENV{PATH}" python -m v2python.generate_compile --target_gpus ${TARGET_GPUS} --build_dir "${AOTRITON_V2_BUILD_DIR}" --bare_mode
+   COMMAND_ECHO STDOUT
+   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_PARENT_DIR}"
+ )
+@@ -45,7 +45,7 @@ foreach(RULE IN LISTS HSACO_RULES)
+   list(POP_FRONT RULE SIG)
+   if(AOTRITON_COMPRESS_KERNEL)
+     add_custom_command(OUTPUT "${HSACO}.zst"
+-      COMMAND ${CMAKE_COMMAND} -E env VIRTUAL_ENV=${VENV_DIR} "${VENV_DIR}/bin/python"
++      COMMAND ${CMAKE_COMMAND} -E env VIRTUAL_ENV=${VENV_DIR} PATH="/usr/bin:$ENV{PATH}" python
+       "${AOTRITON_COMPILER}"
+       "${SRC}"
+       "--kernel_name" "${KNAME}"
+@@ -62,7 +62,7 @@ foreach(RULE IN LISTS HSACO_RULES)
+     list(APPEND ALL_HSACOS "${HSACO}.zst")
+   else(AOTRITON_COMPRESS_KERNEL)
+     add_custom_command(OUTPUT "${HSACO}"
+-      COMMAND ${CMAKE_COMMAND} -E env VIRTUAL_ENV=${VENV_DIR} "${VENV_DIR}/bin/python"
++      COMMAND ${CMAKE_COMMAND} -E env VIRTUAL_ENV=${VENV_DIR} PATH="/usr/bin:$ENV{PATH}" python
+       "${AOTRITON_COMPILER}"
+       "${SRC}"
+       "--kernel_name" "${KNAME}"
+@@ -113,7 +113,7 @@ message(STATUS "AOTRITON_ZSTD_INCLUDE ${AOTRITON_ZSTD_INCLUDE}")
+ message(STATUS "AOTRITON_SHIM_FLAGS ${AOTRITON_SHIM_FLAGS}")
+ 
+ execute_process(
+-  COMMAND ${CMAKE_COMMAND} -E env VIRTUAL_ENV=${VENV_DIR} "${VENV_DIR}/bin/python" -m v2python.generate_shim --target_gpus ${TARGET_GPUS} --build_dir ${AOTRITON_V2_BUILD_DIR} --bare_mode
++  COMMAND ${CMAKE_COMMAND} -E env VIRTUAL_ENV=${VENV_DIR} PATH="/usr/bin:$ENV{PATH}" python -m v2python.generate_shim --target_gpus ${TARGET_GPUS} --build_dir ${AOTRITON_V2_BUILD_DIR} --bare_mode
+   COMMAND_ECHO STDOUT
+   WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/.."
+ )
+@@ -122,7 +122,7 @@ file(STRINGS "${AOTRITON_V2_BUILD_DIR}/Bare.shim" SHIM_CC_FILES)
+ # CAVEAT: Actual shim code can only be generated during build phase because it
+ # requires some kernel information. (Notably shared memory requirement)
+ add_custom_target(aotriton_v2_gen_shim 
+-  COMMAND ${CMAKE_COMMAND} -E env VIRTUAL_ENV=${VENV_DIR} "${VENV_DIR}/bin/python" -m v2python.generate_shim --target_gpus ${TARGET_GPUS} --build_dir ${AOTRITON_V2_BUILD_DIR} ${AOTRITON_SHIM_FLAGS}
++  COMMAND ${CMAKE_COMMAND} -E env VIRTUAL_ENV=${VENV_DIR} PATH="/usr/bin:$ENV{PATH}" python -m v2python.generate_shim --target_gpus ${TARGET_GPUS} --build_dir ${AOTRITON_V2_BUILD_DIR} ${AOTRITON_SHIM_FLAGS}
+   BYPRODUCTS ${SHIM_CC_FILES}  # Essential, otherwise add_library complains
+   COMMAND_EXPAND_LISTS
+   WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/.."
+-- 
+2.43.5
+

--- a/overrides/patches/aotriton-0.6b0/0002-Add-pybind11-dependency-and-remove-build-deltas.patch
+++ b/overrides/patches/aotriton-0.6b0/0002-Add-pybind11-dependency-and-remove-build-deltas.patch
@@ -1,0 +1,107 @@
+From 55ae25284806f3838aec874817f188fc4f3694af Mon Sep 17 00:00:00 2001
+From: Joseph Groenenboom <jgroenen@redhat.com>
+Date: Mon, 30 Sep 2024 14:45:47 -0400
+Subject: [PATCH 1/2] Add pybind11 dependency and remove build deltas.
+
+---
+ python/setup.py | 77 ++-----------------------------------------------
+ 1 file changed, 3 insertions(+), 74 deletions(-)
+
+diff --git a/third_party/triton/python/setup.py b/python/setup.py
+index 55425adf1..c34670cc3 100644
+--- a/third_party/triton/python/setup.py
++++ b/third_party/triton/python/setup.py
+@@ -1,5 +1,6 @@
+ import os
+ import platform
++import pybind11
+ import re
+ import shutil
+ import subprocess
+@@ -46,81 +47,9 @@ def get_codegen_backends():
+ 
+ # --- third party packages -----
+ 
+-
+-class Package(NamedTuple):
+-    package: str
+-    name: str
+-    url: str
+-    include_flag: str
+-    lib_flag: str
+-    syspath_var_name: str
+-
+-
+-# pybind11
+-
+-
+-def get_pybind11_package_info():
+-    name = "pybind11-2.11.1"
+-    url = "https://github.com/pybind/pybind11/archive/refs/tags/v2.11.1.tar.gz"
+-    return Package("pybind11", name, url, "PYBIND11_INCLUDE_DIR", "", "PYBIND11_SYSPATH")
+-
+-
+-# llvm
+-
+-
+-def get_llvm_package_info():
+-    # added statement for Apple Silicon
+-    system = platform.system()
+-    arch = platform.machine()
+-    if arch == 'aarch64':
+-        arch = 'arm64'
+-    if system == "Darwin":
+-        arch = platform.machine()
+-        if arch == "x86_64":
+-            arch = "x64"
+-        system_suffix = f"macos-{arch}"
+-    elif system == "Linux":
+-        # TODO: arm64
+-        vglibc = tuple(map(int, platform.libc_ver()[1].split('.')))
+-        vglibc = vglibc[0] * 100 + vglibc[1]
+-        system_suffix = 'ubuntu-x64' if vglibc > 217 else 'centos-x64'
+-    else:
+-        return Package("llvm", "LLVM-C.lib", "", "LLVM_INCLUDE_DIRS", "LLVM_LIBRARY_DIR", "LLVM_SYSPATH")
+-    # use_assert_enabled_llvm = check_env_flag("TRITON_USE_ASSERT_ENABLED_LLVM", "False")
+-    # release_suffix = "assert" if use_assert_enabled_llvm else "release"
+-    rev = "49af6502"
+-    name = f"llvm-{rev}-{system_suffix}"
+-    url = f"https://tritonlang.blob.core.windows.net/llvm-builds/{name}.tar.gz"
+-    return Package("llvm", name, url, "LLVM_INCLUDE_DIRS", "LLVM_LIBRARY_DIR", "LLVM_SYSPATH")
+-
+-
+ def get_thirdparty_packages(triton_cache_path):
+-    packages = [get_pybind11_package_info(), get_llvm_package_info()]
+-    thirdparty_cmake_args = []
+-    for p in packages:
+-        package_root_dir = os.path.join(triton_cache_path, p.package)
+-        package_dir = os.path.join(package_root_dir, p.name)
+-        if p.syspath_var_name in os.environ:
+-            package_dir = os.environ[p.syspath_var_name]
+-        version_file_path = os.path.join(package_dir, "version.txt")
+-        if p.syspath_var_name not in os.environ and\
+-           (not os.path.exists(version_file_path) or Path(version_file_path).read_text() != p.url):
+-            try:
+-                shutil.rmtree(package_root_dir)
+-            except Exception:
+-                pass
+-            os.makedirs(package_root_dir, exist_ok=True)
+-            print(f'downloading and extracting {p.url} ...')
+-            ftpstream = urllib.request.urlopen(p.url)
+-            file = tarfile.open(fileobj=ftpstream, mode="r|*")
+-            file.extractall(path=package_root_dir)
+-            # write version url to package_dir
+-            with open(os.path.join(package_dir, "version.txt"), "w") as f:
+-                f.write(p.url)
+-        if p.include_flag:
+-            thirdparty_cmake_args.append(f"-D{p.include_flag}={package_dir}/include")
+-        if p.lib_flag:
+-            thirdparty_cmake_args.append(f"-D{p.lib_flag}={package_dir}/lib")
++    llvm_syspath = os.environ["LLVM_SYSPATH"]
++    thirdparty_cmake_args = [f"-DPYBIND11_INCLUDE_DIR={pybind11.get_include()}", f"-DLLVM_INCLUDE_DIRS={llvm_syspath}/include", f"-DLLVM_LIBRARY_DIR={llvm_syspath}/lib"]
+     return thirdparty_cmake_args
+ 
+ 
+-- 
+2.43.5
+

--- a/overrides/patches/aotriton-0.6b0/0003-Remove-AOTriton-unit-tests-from-Triton.patch
+++ b/overrides/patches/aotriton-0.6b0/0003-Remove-AOTriton-unit-tests-from-Triton.patch
@@ -1,0 +1,22 @@
+From 8f23770b6cb93357e13240e9a16194631fdef455 Mon Sep 17 00:00:00 2001
+From: Joseph Groenenboom <jgroenen@redhat.com>
+Date: Mon, 30 Sep 2024 14:57:01 -0400
+Subject: [PATCH 2/2] Remove AOTriton unit tests from Triton
+
+---
+ CMakeLists.txt | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/third_party/triton/CMakeLists.txt b/third_party/triton/CMakeLists.txt
+index 55a5d8b3b..c302661cc 100644
+--- a/third_party/triton/CMakeLists.txt
++++ b/third_party/triton/CMakeLists.txt
+@@ -309,5 +309,3 @@ if (${CODEGEN_BACKENDS_LEN} GREATER 0)
+ endif()
+ 
+ add_subdirectory(test)
+-
+-add_subdirectory(unittest)
+-- 
+2.43.5
+

--- a/overrides/patches/aotriton-0.6b0/0005-fix-generate-shim.patch
+++ b/overrides/patches/aotriton-0.6b0/0005-fix-generate-shim.patch
@@ -1,0 +1,12 @@
+diff -urNp aotriton-0.6b0.orig/v2python/generate_shim.py aotriton-0.6b0/v2python/generate_shim.py
+--- aotriton-0.6b0.orig/v2python/generate_shim.py	2024-10-30 14:54:40.662345216 -0400
++++ aotriton-0.6b0/v2python/generate_shim.py	2024-10-30 15:06:08.669372413 -0400
+@@ -223,7 +223,7 @@ class ShimMakefileGenerator(MakefileGene
+                 print('\t', '${AR} -r ', fn, '@ar.txt', file=f)
+                 print(all_object_files, file=self._arf)
+             if s == '.so':
+-                print('\t', COMPILER, ' -g -shared -fPIC -o ', fn, all_object_files, file=f)
++                print('\t', COMPILER, ' -g -shared -fPIC -o ', fn, ' @ar.txt', file=f)
+             print('\n\n', file=f)
+ 
+     '''

--- a/overrides/patches/deepspeed-0.15.2/0001-use-io-getevents.patch
+++ b/overrides/patches/deepspeed-0.15.2/0001-use-io-getevents.patch
@@ -1,0 +1,49 @@
+Revert use of io_pgetevents
+
+io_pgetevent with NULL as sigmask behaves exactly like io_getevents.
+
+Revert feature check back to io_submit.
+
+diff --git a/csrc/aio/common/deepspeed_aio_common.cpp b/csrc/aio/common/deepspeed_aio_common.cpp
+index a65cc500..e1b184e3 100644
+--- a/csrc/aio/common/deepspeed_aio_common.cpp
++++ b/csrc/aio/common/deepspeed_aio_common.cpp
+@@ -115,11 +115,10 @@ static int _do_io_complete(const long long int min_completes,
+                            std::vector<std::chrono::duration<double>>& reap_times)
+ {
+     const auto start_time = std::chrono::high_resolution_clock::now();
+-    long long int n_completes = io_pgetevents(aio_ctxt->_io_ctxt,
++    long long int n_completes = io_getevents(aio_ctxt->_io_ctxt,
+                                               min_completes,
+                                               max_completes,
+                                               aio_ctxt->_io_events.data(),
+-                                              nullptr,
+                                               nullptr);
+     reap_times.push_back(std::chrono::high_resolution_clock::now() - start_time);
+     assert(n_completes >= min_completes);
+diff --git a/op_builder/npu/async_io.py b/op_builder/npu/async_io.py
+index 76d495b8..fa43312a 100644
+--- a/op_builder/npu/async_io.py
++++ b/op_builder/npu/async_io.py
+@@ -89,7 +89,7 @@ class AsyncIOBuilder(NPUOpBuilder):
+         # which is a function provided by libaio that is used in the async_io op.
+         # If needed, one can define -I and -L entries in CFLAGS and LDFLAGS
+         # respectively to specify the directories for libaio.h and libaio.so.
+-        aio_compatible = self.has_function('io_pgetevents', ('aio', ))
++        aio_compatible = self.has_function('io_submit', ('aio', ))
+         if verbose and not aio_compatible:
+             self.warning(f"{self.NAME} requires the dev libaio .so object and headers but these were not found.")
+ 
+diff --git a/op_builder/xpu/async_io.py b/op_builder/xpu/async_io.py
+index 2da963ae..c5dde549 100644
+--- a/op_builder/xpu/async_io.py
++++ b/op_builder/xpu/async_io.py
+@@ -92,7 +92,7 @@ class AsyncIOBuilder(OpBuilder):
+         # which is a function provided by libaio that is used in the async_io op.
+         # If needed, one can define -I and -L entries in CFLAGS and LDFLAGS
+         # respectively to specify the directories for libaio.h and libaio.so.
+-        aio_compatible = self.has_function('io_pgetevents', ('aio', ))
++        aio_compatible = self.has_function('io_submit', ('aio', ))
+         if verbose and not aio_compatible:
+             self.warning(f"{self.NAME} requires the dev libaio .so object and headers but these were not found.")
+ 

--- a/overrides/patches/flash_attn-2.6.3/001-stop-submodule-download.patch
+++ b/overrides/patches/flash_attn-2.6.3/001-stop-submodule-download.patch
@@ -1,0 +1,17 @@
+diff --git a/setup.py b/setup.py
+--- a/setup.py
++++ b/setup.py
+@@ -136,13 +136,6 @@
+ cmdclass = {}
+ ext_modules = []
+ 
+-# We want this even if SKIP_CUDA_BUILD because when we run python setup.py sdist we want the .hpp
+-# files included in the source distribution, in case the user compiles from source.
+-if IS_ROCM:
+-    subprocess.run(["git", "submodule", "update", "--init", "csrc/composable_kernel"])
+-else:
+-    subprocess.run(["git", "submodule", "update", "--init", "csrc/cutlass"])
+-
+ if not SKIP_CUDA_BUILD and not IS_ROCM:
+     print("\n\ntorch.__version__  = {}\n\n".format(torch.__version__))
+     TORCH_MAJOR = int(torch.__version__.split(".")[0])

--- a/overrides/patches/flash_attn-2.7.2.post1/001-stop-submodule-download.patch
+++ b/overrides/patches/flash_attn-2.7.2.post1/001-stop-submodule-download.patch
@@ -1,0 +1,18 @@
+diff --git a/setup.py b/setup.py
+--- a/setup.py
++++ b/setup.py
+@@ -136,14 +136,6 @@
+ cmdclass = {}
+ ext_modules = []
+ 
+-# We want this even if SKIP_CUDA_BUILD because when we run python setup.py sdist we want the .hpp
+-# files included in the source distribution, in case the user compiles from source.
+-if IS_ROCM:
+-    if not USE_TRITON_ROCM:
+-        subprocess.run(["git", "submodule", "update", "--init", "csrc/composable_kernel"])
+-else:
+-    subprocess.run(["git", "submodule", "update", "--init", "csrc/cutlass"])
+-
+ if not SKIP_CUDA_BUILD and not IS_ROCM:
+     print("\n\ntorch.__version__  = {}\n\n".format(torch.__version__))
+     TORCH_MAJOR = int(torch.__version__.split(".")[0])

--- a/overrides/patches/gradlib-0.6.2/001-Set-package-version.patch
+++ b/overrides/patches/gradlib-0.6.2/001-Set-package-version.patch
@@ -1,0 +1,11 @@
+diff --git a/setup.py b/setup.py
+--- a/setup.py
++++ b/setup.py
+@@ -158,6 +158,7 @@
+ 
+ setup(name='gradlib',
+       packages=['gradlib'],
++      version='0.6.2',
+       ext_modules=ext_modules,
+       cmdclass={'build_ext': BuildExtension})
+ 

--- a/overrides/patches/ninja-1.11.1.1/wrap-system-ninja.patch
+++ b/overrides/patches/ninja-1.11.1.1/wrap-system-ninja.patch
@@ -1,0 +1,288 @@
+Quick hack to have the ninja wheel wrap the binary from the ninja-build
+RPM rather than including a binary in the weel.
+
+Probably plenty more to investigate here - e.g. this can now be an
+arch-independent wheel.
+
+ninja_syntax.py comes from the misc/ dir in
+https://github.com/Kitware/ninja/archive/v1.11.1.g95dee.kitware.jobserver-1.tar.gz
+
+Simple test that this works ...
+
+Upstream wheel:
+
+ $ ninja --version
+ 1.11.1.git.kitware.jobserver-1
+
+With this patch:
+
+ $ rpm -q ninja-build
+ ninja-build-1.10.2-6.el9.x86_64
+ $ /usr/bin/ninja --version
+ 1.10.2
+ $ which ninja
+ .../work-dir/venv-python3.9/bin/ninja
+ $ ninja --version
+ 1.10.2
+
+diff -urNp ninja-1.11.1.1.orig/setup.py ninja-1.11.1.1/setup.py
+--- ninja-1.11.1.1.orig/setup.py	2023-10-09 18:05:36.000000000 +0100
++++ ninja-1.11.1.1/setup.py	2024-04-08 09:22:04.310838229 +0100
+@@ -5,7 +5,8 @@ import os
+ import sys
+ from distutils.text_file import TextFile
+ 
+-from skbuild import setup
++#from skbuild import setup
++from setuptools import setup
+ 
+ # Add current folder to path
+ # This is required to import versioneer in an isolated pip build
+diff -urNp ninja-1.11.1.1.orig/src/ninja/__init__.py ninja-1.11.1.1/src/ninja/__init__.py
+--- ninja-1.11.1.1.orig/src/ninja/__init__.py	2023-10-09 18:05:36.000000000 +0100
++++ ninja-1.11.1.1/src/ninja/__init__.py	2024-04-08 09:25:45.330541151 +0100
+@@ -13,38 +13,11 @@ def __dir__():
+     return __all__
+ 
+ 
+-try:
+-    from .ninja_syntax import Writer, escape, expand
+-except ImportError:
+-    # Support importing `ninja_syntax` from the source tree
+-    if not os.path.exists(
+-            os.path.join(os.path.dirname(__file__), 'ninja_syntax.py')):
+-        sys.path.insert(0, os.path.abspath(os.path.join(
+-            os.path.dirname(__file__), '../../Ninja-src/misc')))
+-    from ninja_syntax import Writer, escape, expand  # noqa: F401
++from .ninja_syntax import Writer, escape, expand
+ 
+-DATA = os.path.join(os.path.dirname(__file__), 'data')
+-
+-# Support running tests from the source tree
+-if not os.path.exists(DATA):
+-    from skbuild.constants import CMAKE_INSTALL_DIR as SKBUILD_CMAKE_INSTALL_DIR
+-    from skbuild.constants import set_skbuild_plat_name
+-
+-    if platform.system().lower() == "darwin":
+-        # Since building the project specifying --plat-name or CMAKE_OSX_* variables
+-        # leads to different SKBUILD_DIR, the code below attempt to guess the most
+-        # likely plat-name.
+-        _skbuild_dirs = os.listdir(os.path.join(os.path.dirname(__file__), '..', '..', '_skbuild'))
+-        if _skbuild_dirs:
+-            _likely_plat_name = '-'.join(_skbuild_dirs[0].split('-')[:3])
+-            set_skbuild_plat_name(_likely_plat_name)
+-
+-    _data = os.path.abspath(os.path.join(
+-        os.path.dirname(__file__), '..', '..', SKBUILD_CMAKE_INSTALL_DIR(), 'src/ninja/data'))
+-    if os.path.exists(_data):
+-        DATA = _data
+ 
+-BIN_DIR = os.path.join(DATA, 'bin')
++DATA = os.path.join(os.path.dirname(__file__), 'data')
++BIN_DIR = '/usr/bin'
+ 
+ 
+ def _program(name, args):
+diff -urNp ninja-1.11.1.1.orig/src/ninja/ninja_syntax.py ninja-1.11.1.1/src/ninja/ninja_syntax.py
+--- ninja-1.11.1.1.orig/src/ninja/ninja_syntax.py	1970-01-01 01:00:00.000000000 +0100
++++ ninja-1.11.1.1/src/ninja/ninja_syntax.py	2024-04-08 09:22:04.310838229 +0100
+@@ -0,0 +1,199 @@
++#!/usr/bin/python
++
++# Copyright 2011 Google Inc. All Rights Reserved.
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++"""Python module for generating .ninja files.
++
++Note that this is emphatically not a required piece of Ninja; it's
++just a helpful utility for build-file-generation systems that already
++use Python.
++"""
++
++import re
++import textwrap
++
++def escape_path(word):
++    return word.replace('$ ', '$$ ').replace(' ', '$ ').replace(':', '$:')
++
++class Writer(object):
++    def __init__(self, output, width=78):
++        self.output = output
++        self.width = width
++
++    def newline(self):
++        self.output.write('\n')
++
++    def comment(self, text):
++        for line in textwrap.wrap(text, self.width - 2, break_long_words=False,
++                                  break_on_hyphens=False):
++            self.output.write('# ' + line + '\n')
++
++    def variable(self, key, value, indent=0):
++        if value is None:
++            return
++        if isinstance(value, list):
++            value = ' '.join(filter(None, value))  # Filter out empty strings.
++        self._line('%s = %s' % (key, value), indent)
++
++    def pool(self, name, depth):
++        self._line('pool %s' % name)
++        self.variable('depth', depth, indent=1)
++
++    def rule(self, name, command, description=None, depfile=None,
++             generator=False, pool=None, restat=False, rspfile=None,
++             rspfile_content=None, deps=None):
++        self._line('rule %s' % name)
++        self.variable('command', command, indent=1)
++        if description:
++            self.variable('description', description, indent=1)
++        if depfile:
++            self.variable('depfile', depfile, indent=1)
++        if generator:
++            self.variable('generator', '1', indent=1)
++        if pool:
++            self.variable('pool', pool, indent=1)
++        if restat:
++            self.variable('restat', '1', indent=1)
++        if rspfile:
++            self.variable('rspfile', rspfile, indent=1)
++        if rspfile_content:
++            self.variable('rspfile_content', rspfile_content, indent=1)
++        if deps:
++            self.variable('deps', deps, indent=1)
++
++    def build(self, outputs, rule, inputs=None, implicit=None, order_only=None,
++              variables=None, implicit_outputs=None, pool=None, dyndep=None):
++        outputs = as_list(outputs)
++        out_outputs = [escape_path(x) for x in outputs]
++        all_inputs = [escape_path(x) for x in as_list(inputs)]
++
++        if implicit:
++            implicit = [escape_path(x) for x in as_list(implicit)]
++            all_inputs.append('|')
++            all_inputs.extend(implicit)
++        if order_only:
++            order_only = [escape_path(x) for x in as_list(order_only)]
++            all_inputs.append('||')
++            all_inputs.extend(order_only)
++        if implicit_outputs:
++            implicit_outputs = [escape_path(x)
++                                for x in as_list(implicit_outputs)]
++            out_outputs.append('|')
++            out_outputs.extend(implicit_outputs)
++
++        self._line('build %s: %s' % (' '.join(out_outputs),
++                                     ' '.join([rule] + all_inputs)))
++        if pool is not None:
++            self._line('  pool = %s' % pool)
++        if dyndep is not None:
++            self._line('  dyndep = %s' % dyndep)
++
++        if variables:
++            if isinstance(variables, dict):
++                iterator = iter(variables.items())
++            else:
++                iterator = iter(variables)
++
++            for key, val in iterator:
++                self.variable(key, val, indent=1)
++
++        return outputs
++
++    def include(self, path):
++        self._line('include %s' % path)
++
++    def subninja(self, path):
++        self._line('subninja %s' % path)
++
++    def default(self, paths):
++        self._line('default %s' % ' '.join(as_list(paths)))
++
++    def _count_dollars_before_index(self, s, i):
++        """Returns the number of '$' characters right in front of s[i]."""
++        dollar_count = 0
++        dollar_index = i - 1
++        while dollar_index > 0 and s[dollar_index] == '$':
++            dollar_count += 1
++            dollar_index -= 1
++        return dollar_count
++
++    def _line(self, text, indent=0):
++        """Write 'text' word-wrapped at self.width characters."""
++        leading_space = '  ' * indent
++        while len(leading_space) + len(text) > self.width:
++            # The text is too wide; wrap if possible.
++
++            # Find the rightmost space that would obey our width constraint and
++            # that's not an escaped space.
++            available_space = self.width - len(leading_space) - len(' $')
++            space = available_space
++            while True:
++                space = text.rfind(' ', 0, space)
++                if (space < 0 or
++                    self._count_dollars_before_index(text, space) % 2 == 0):
++                    break
++
++            if space < 0:
++                # No such space; just use the first unescaped space we can find.
++                space = available_space - 1
++                while True:
++                    space = text.find(' ', space + 1)
++                    if (space < 0 or
++                        self._count_dollars_before_index(text, space) % 2 == 0):
++                        break
++            if space < 0:
++                # Give up on breaking.
++                break
++
++            self.output.write(leading_space + text[0:space] + ' $\n')
++            text = text[space+1:]
++
++            # Subsequent lines are continuations, so indent them.
++            leading_space = '  ' * (indent+2)
++
++        self.output.write(leading_space + text + '\n')
++
++    def close(self):
++        self.output.close()
++
++
++def as_list(input):
++    if input is None:
++        return []
++    if isinstance(input, list):
++        return input
++    return [input]
++
++
++def escape(string):
++    """Escape a string such that it can be embedded into a Ninja file without
++    further interpretation."""
++    assert '\n' not in string, 'Ninja syntax does not allow newlines'
++    # We only have one special metacharacter: '$'.
++    return string.replace('$', '$$')
++
++
++def expand(string, vars, local_vars={}):
++    """Expand a string containing $vars as Ninja would.
++
++    Note: doesn't handle the full Ninja variable syntax, but it's enough
++    to make configure.py's use of it work.
++    """
++    def exp(m):
++        var = m.group(1)
++        if var == '$':
++            return '$'
++        return local_vars.get(var, vars.get(var, ''))
++    return re.sub(r'\$(\$|\w*)', exp, string)

--- a/overrides/patches/symengine-0.9.2/0001-Fix-fix-latest-setuptools.patch
+++ b/overrides/patches/symengine-0.9.2/0001-Fix-fix-latest-setuptools.patch
@@ -1,0 +1,21 @@
+From 987e665e71cf92d1b021d7d573a1b9733408eecf Mon Sep 17 00:00:00 2001
+From: Isuru Fernando <isuruf@gmail.com>
+Date: Sat, 2 Apr 2022 15:43:00 -0500
+Subject: [PATCH] Fix for latest setuptools
+
+---
+ setup.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/setup.py b/setup.py
+index 346e1db0..33365e5b 100644
+--- a/setup.py
++++ b/setup.py
+@@ -226,6 +226,7 @@ def finalize_options(self):
+       url="https://github.com/symengine/symengine.py",
+       python_requires='>=3.7,<4',
+       zip_safe=False,
++      packages=['symengine'],
+       cmdclass = cmdclass,
+       classifiers=[
+         'License :: OSI Approved :: MIT License',

--- a/overrides/patches/symengine-0.9.2/0002-Fix-build-to-avoid-duplicate-files-in-wheel.patch
+++ b/overrides/patches/symengine-0.9.2/0002-Fix-build-to-avoid-duplicate-files-in-wheel.patch
@@ -1,0 +1,97 @@
+From bc84086d60de038eb381c9e37c8b552a6c246ab5 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micha=C5=82=20G=C3=B3rny?= <mgorny@gentoo.org>
+Date: Mon, 2 May 2022 09:24:45 +0200
+Subject: [PATCH] Fix build to avoid duplicate files in wheel
+
+Fix the build system to package pure Python files
+via distutils/setuptools, and limit CMake to installing the compiled
+extension.
+
+The prior logic has installed some of the .py files both via setuptools
+and via CMake, to different build directories.  As a result,
+the resulting wheel contained duplicate files, e.g.:
+
+         2170  05-02-2022 07:08   symengine/__init__.py
+         2170  05-02-2022 07:08   symengine-0.9.2.data/purelib/symengine/__init__.py
+
+Duplicate files cause the wheel to be rejected by the installer package.
+
+After the change, a correct wheel is generated.  Installation works
+both via PEP517/wheel and via legacy `setup.py install`.
+---
+ setup.py                       |  2 +-
+ symengine/CMakeLists.txt       |  6 ------
+ symengine/lib/CMakeLists.txt   |  2 +-
+ symengine/tests/CMakeLists.txt | 25 -------------------------
+ 4 files changed, 2 insertions(+), 33 deletions(-)
+ delete mode 100644 symengine/tests/CMakeLists.txt
+
+diff --git a/setup.py b/setup.py
+index 33365e5b2..808dac93f 100644
+--- a/setup.py
++++ b/setup.py
+@@ -226,7 +226,7 @@ def finalize_options(self):
+       url="https://github.com/symengine/symengine.py",
+       python_requires='>=3.7,<4',
+       zip_safe=False,
+-      packages=['symengine'],
++      packages=['symengine', 'symengine.lib', 'symengine.tests'],
+       cmdclass = cmdclass,
+       classifiers=[
+         'License :: OSI Approved :: MIT License',
+diff --git a/symengine/CMakeLists.txt b/symengine/CMakeLists.txt
+index a666f7421..3ea7a4199 100644
+--- a/symengine/CMakeLists.txt
++++ b/symengine/CMakeLists.txt
+@@ -1,7 +1 @@
+ add_subdirectory(lib)
+-add_subdirectory(tests)
+-
+-set(PY_PATH ${PYTHON_INSTALL_PATH}/symengine)
+-install(FILES __init__.py utilities.py sympy_compat.py functions.py printing.py
+-    DESTINATION ${PY_PATH}
+-    )
+diff --git a/symengine/lib/CMakeLists.txt b/symengine/lib/CMakeLists.txt
+index 33f813ff1..87b1ab9d4 100644
+--- a/symengine/lib/CMakeLists.txt
++++ b/symengine/lib/CMakeLists.txt
+@@ -28,7 +28,7 @@ install(TARGETS symengine_wrapper
+             ARCHIVE DESTINATION ${PY_PATH}
+             LIBRARY DESTINATION ${PY_PATH}
+         )
+-install(FILES __init__.py
++install(FILES
+     ${CMAKE_CURRENT_BINARY_DIR}/config.pxi
+     symengine.pxd
+     symengine_wrapper.pxd
+diff --git a/symengine/tests/CMakeLists.txt b/symengine/tests/CMakeLists.txt
+deleted file mode 100644
+index ebd4dfaa2..000000000
+--- a/symengine/tests/CMakeLists.txt
++++ /dev/null
+@@ -1,25 +0,0 @@
+-set(PY_PATH ${PYTHON_INSTALL_PATH}/symengine/tests)
+-install(FILES __init__.py
+-    test_arit.py
+-    test_dict_basic.py
+-    test_eval.py
+-    test_expr.py
+-    test_functions.py
+-    test_number.py
+-    test_matrices.py
+-    test_ntheory.py
+-    test_printing.py
+-    test_sage.py
+-    test_series_expansion.py
+-    test_sets.py
+-    test_solve.py
+-    test_subs.py
+-    test_symbol.py
+-    test_sympify.py
+-    test_sympy_conv.py
+-    test_var.py
+-    test_lambdify.py
+-    test_sympy_compat.py
+-    test_logic.py
+-    DESTINATION ${PY_PATH}
+-    )

--- a/overrides/patches/symengine-0.9.2/0003-Use-setuptools-command-build.patch
+++ b/overrides/patches/symengine-0.9.2/0003-Use-setuptools-command-build.patch
@@ -1,0 +1,40 @@
+From eba314ac0e29de79554ac5f3717730169dbbb5bc Mon Sep 17 00:00:00 2001
+From: Isuru Fernando <isuruf@gmail.com>
+Date: Mon, 20 Mar 2023 16:30:02 -0500
+Subject: [PATCH] Use setuptools.command.build if available
+
+---
+ setup.py | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index 6242769d..88f2d1c7 100644
+--- a/setup.py
++++ b/setup.py
+@@ -22,8 +22,6 @@
+         print("Value {} for USE_DISTUTILS treated as False".
+               format(use_distutils))
+ 
+-from distutils.command.build import build as _build
+-
+ if use_setuptools:
+     try:
+         from setuptools import setup
+@@ -31,11 +29,17 @@
+         from setuptools.command.build_ext import build_ext as _build_ext
+     except ImportError:
+         use_setuptools = False
++    else:
++        try:
++            from setuptools.command.build import build as _build
++        except ImportError:
++            from distutils.command.build import build as _build
+ 
+ if not use_setuptools:
+     from distutils.core import setup
+     from distutils.command.install import install as _install
+     from distutils.command.build_ext import build_ext as _build_ext
++    from distutils.command.build import build as _build
+ 
+ cmake_opts = [("PYTHON_BIN", sys.executable),
+               ("CMAKE_INSTALL_RPATH_USE_LINK_PATH", "yes")]

--- a/overrides/patches/symengine-0.9.2/0100-Support-NaN-in-LLVM-and-Lambda-visitors.patch
+++ b/overrides/patches/symengine-0.9.2/0100-Support-NaN-in-LLVM-and-Lambda-visitors.patch
@@ -1,0 +1,116 @@
+From 98e82c2ae46011c9444b4c7061b5a0d537e390a4 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Bj=C3=B6rn=20Ingvar=20Dahlgren?= <bjodah@gmail.com>
+Date: Mon, 21 Feb 2022 20:15:46 +0100
+Subject: [PATCH] Support NaN in LLVM- and Lambda visitors
+
+---
+ symengine/lambda_double.h                   |  8 +++++++-
+ symengine/llvm_double.cpp                   |  6 ++++++
+ symengine/llvm_double.h                     |  1 +
+ symengine/tests/eval/test_lambda_double.cpp | 17 +++++++++++++++++
+ 4 files changed, 31 insertions(+), 1 deletion(-)
+
+diff --git a/libsymengine/symengine/lambda_double.h b/libsymengine/symengine/lambda_double.h
+index 6442770eb..bf6f00dea 100644
+--- a/libsymengine/symengine/lambda_double.h
++++ b/libsymengine/symengine/lambda_double.h
+@@ -560,7 +560,13 @@ public:
+                 "LambdaDouble can only represent real valued infinity");
+         }
+     }
+-
++    void bvisit(const NaN &nan)
++    {
++        assert(&nan == &(*Nan) /* singleton, or do we support NaN quiet/singaling nan with payload? */);
++        result_ = [](const double * /* x  */) {
++            return std::numeric_limits<double>::signaling_NaN();
++        };
++    }
+     void bvisit(const Contains &cts)
+     {
+         const auto fn_expr = apply(*cts.get_expr());
+diff --git a/libsymengine/symengine/llvm_double.cpp b/libsymengine/symengine/llvm_double.cpp
+index f7d5ea413..f8e02631d 100644
+--- a/libsymengine/symengine/llvm_double.cpp
++++ b/libsymengine/symengine/llvm_double.cpp
+@@ -697,6 +697,12 @@ void LLVMVisitor::bvisit(const Infty &x)
+     }
+ }
+ 
++void LLVMVisitor::bvisit(const NaN &x)
++{
++    result_ = llvm::ConstantFP::getSNaN(get_float_type(&mod->getContext()),
++                                        /*negative=*/false, /*payload=*/0);
++}
++
+ void LLVMVisitor::bvisit(const BooleanAtom &x)
+ {
+     const bool val = x.get_val();
+diff --git a/libsymengine/symengine/llvm_double.h b/libsymengine/symengine/llvm_double.h
+index ee33b18c5..6ce4b9e57 100644
+--- a/libsymengine/symengine/llvm_double.h
++++ b/libsymengine/symengine/llvm_double.h
+@@ -99,6 +99,7 @@ public:
+     void bvisit(const Min &x);
+     void bvisit(const Contains &x);
+     void bvisit(const Infty &x);
++    void bvisit(const NaN &x);
+     void bvisit(const Floor &x);
+     void bvisit(const Ceiling &x);
+     void bvisit(const Truncate &x);
+diff --git a/libsymengine/symengine/tests/eval/test_lambda_double.cpp b/libsymengine/symengine/tests/eval/test_lambda_double.cpp
+index a02553de0..4389169a4 100644
+--- a/libsymengine/symengine/tests/eval/test_lambda_double.cpp
++++ b/libsymengine/symengine/tests/eval/test_lambda_double.cpp
+@@ -1,4 +1,6 @@
+ #include "catch.hpp"
++#include "symengine/constants.h"
++#include "symengine/nan.h"
+ #include <chrono>
+ #include <array>
+ 
+@@ -49,6 +51,7 @@ using SymEngine::Eq;
+ using SymEngine::evalf;
+ using SymEngine::floor;
+ using SymEngine::gamma;
++using SymEngine::Inf;
+ using SymEngine::integer;
+ using SymEngine::LambdaComplexDoubleVisitor;
+ using SymEngine::LambdaRealDoubleVisitor;
+@@ -61,6 +64,7 @@ using SymEngine::map_basic_basic;
+ using SymEngine::max;
+ using SymEngine::min;
+ using SymEngine::mul;
++using SymEngine::Nan;
+ using SymEngine::Ne;
+ using SymEngine::NegInf;
+ using SymEngine::NotImplementedError;
+@@ -274,6 +278,12 @@ TEST_CASE("Evaluate functions", "[lambda_gamma]")
+             REQUIRE(::fabs(d - ref) < 1e-12);
+         }
+     }
++    v.init({}, *Nan);
++    REQUIRE(std::isnan(v.call({})));
++    v.init({}, *Inf);
++    std::isinf(v.call({}));
++    v.init({}, *NegInf);
++    REQUIRE(std::isinf(v.call({})));
+ }
+ 
+ #ifdef HAVE_SYMENGINE_LLVM
+@@ -334,6 +344,13 @@ TEST_CASE("Check llvm and lambda are equal", "[llvm_double]")
+         REQUIRE(::fabs((d - d2)) < 1e-12);
+         REQUIRE(::fabs((d - d3)) < 1e-12);
+     }
++    {
++        double out[2];
++        LLVMDoubleVisitor v;
++        v.init({}, {*Nan, *Inf});
++        v.call(out, {}) REQUIRE(std::isnan(out[0]));
++        REQUIRE(std::isinf(out[1]));
++    }
+ }
+ 
+ TEST_CASE("Check llvm with opt_level 0-3 is equal to llvm without opt_level",
+-- 
+2.47.0

--- a/overrides/patches/symengine-0.9.2/0101-getSNaN-not-in-LLVM-3.8-on-MacOS-build.patch
+++ b/overrides/patches/symengine-0.9.2/0101-getSNaN-not-in-LLVM-3.8-on-MacOS-build.patch
@@ -1,0 +1,26 @@
+From 3d9432280da203ec572c09033ac4472aa1cdb5f9 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Bj=C3=B6rn=20Ingvar=20Dahlgren?= <bjodah@gmail.com>
+Date: Mon, 21 Feb 2022 22:23:00 +0100
+Subject: [PATCH] getSNaN not in LLVM-3.8 on MacOS build
+
+---
+ symengine/llvm_double.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/libsymengine/symengine/llvm_double.cpp b/libsymengine/symengine/llvm_double.cpp
+index f8e02631d..b88414c81 100644
+--- a/libsymengine/symengine/llvm_double.cpp
++++ b/libsymengine/symengine/llvm_double.cpp
+@@ -699,8 +699,8 @@ void LLVMVisitor::bvisit(const Infty &x)
+ 
+ void LLVMVisitor::bvisit(const NaN &x)
+ {
+-    result_ = llvm::ConstantFP::getSNaN(get_float_type(&mod->getContext()),
+-                                        /*negative=*/false, /*payload=*/0);
++    result_ = llvm::ConstantFP::getNaN(get_float_type(&mod->getContext()),
++                                       /*negative=*/false, /*payload=*/0);
+ }
+ 
+ void LLVMVisitor::bvisit(const BooleanAtom &x)
+-- 
+2.47.0

--- a/overrides/patches/symengine-0.9.2/0102-fix-run-time-warnings-when-using-llvm-15.patch
+++ b/overrides/patches/symengine-0.9.2/0102-fix-run-time-warnings-when-using-llvm-15.patch
@@ -1,0 +1,32 @@
+From 80448bc5f9f2713f7b16e5dd70869e468b9078fe Mon Sep 17 00:00:00 2001
+From: Liam Keegan <liam@keegan.ch>
+Date: Thu, 17 Feb 2022 14:52:23 +0100
+Subject: [PATCH] fix run-time warnings when using llvm 15
+
+- uwtable now takes a tablekind attribute
+- see https://github.com/llvm/llvm-project/commit/6398903ac8c141820a84f3063b7956abe1742500
+- resolves #1943
+- also bump github actions checkout & cache versions in CI
+---
+ symengine/llvm_double.cpp            | 5 +++++
+ 4 files changed, 11 insertions(+), 6 deletions(-)
+
+diff --git a/libsymengine/symengine/llvm_double.cpp b/libsymengine/symengine/llvm_double.cpp
+index b88414c81..a4e71901a 100644
+--- a/libsymengine/symengine/llvm_double.cpp
++++ b/libsymengine/symengine/llvm_double.cpp
+@@ -130,7 +130,12 @@ llvm::Function *LLVMVisitor::get_function_type(llvm::LLVMContext *context)
+     F->addParamAttr(0, llvm::Attribute::NoCapture);
+     F->addParamAttr(1, llvm::Attribute::NoCapture);
+     F->addFnAttr(llvm::Attribute::NoUnwind);
++#if (LLVM_VERSION_MAJOR < 15)
+     F->addFnAttr(llvm::Attribute::UWTable);
++#else
++    F->addFnAttr(llvm::Attribute::getWithUWTableKind(
++        *context, llvm::UWTableKind::Default));
++#endif
+ #endif
+     return F;
+ }
+-- 
+2.47.0

--- a/overrides/patches/symengine-0.9.2/0103-add-support-for-LLVM-16.patch
+++ b/overrides/patches/symengine-0.9.2/0103-add-support-for-LLVM-16.patch
@@ -1,0 +1,93 @@
+From 8404c2cc5250d6d52ba831a6e1f6d6a99fcdf496 Mon Sep 17 00:00:00 2001
+From: Liam Keegan <liam@keegan.ch>
+Date: Tue, 14 Mar 2023 20:38:49 +0100
+Subject: [PATCH] add support for LLVM 16
+
+- requires C++17
+- `getBasicBlockList()` is now private but they provide an `insert()` method
+- requires CMake policy `CMP0057` (IN_LIST if() operator)
+---
+ CMakeLists.txt            | 6 +++++-
+ symengine/CMakeLists.txt  | 8 ++++++--
+ symengine/llvm_double.cpp | 8 ++++++++
+ 3 files changed, 19 insertions(+), 3 deletions(-)
+
+diff --git a/libsymengine/CMakeLists.txt b/libsymengine/CMakeLists.txt
+index 7f8c09d5b..27b0f9af9 100644
+--- a/libsymengine/CMakeLists.txt
++++ b/libsymengine/CMakeLists.txt
+@@ -1,5 +1,9 @@
+ cmake_minimum_required(VERSION 2.8.12)
+ 
++if (POLICY CMP0057)
++    cmake_policy(SET CMP0057 NEW) # needed for llvm >= 16
++endif ()
++
+ set(CMAKE_USER_MAKE_RULES_OVERRIDE ${CMAKE_CURRENT_SOURCE_DIR}/cmake/UserOverride.cmake)
+ 
+ project(symengine)
+@@ -432,7 +436,6 @@ if (WITH_LLVM)
+     include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
+     set(HAVE_SYMENGINE_LLVM yes)
+     set(PKGS ${PKGS} "LLVM")
+-    message("LLVM VERSION: ${LLVM_VERSION}")
+ endif()
+ 
+ # BENCHMARKS
+@@ -751,6 +754,7 @@ endif()
+ 
+ message("WITH_LLVM: ${WITH_LLVM}")
+ if (WITH_LLVM)
++    message("LLVM VERSION: ${LLVM_VERSION}")
+     message("LLVM_INCLUDE_DIRS: ${LLVM_INCLUDE_DIRS}")
+ endif()
+ 
+diff --git a/libsymengine/symengine/CMakeLists.txt b/libsymengine/symengine/CMakeLists.txt
+index 4da72a741..ae85096ed 100644
+--- a/libsymengine/symengine/CMakeLists.txt
++++ b/libsymengine/symengine/CMakeLists.txt
+@@ -273,8 +273,12 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+     set_source_files_properties(parser/parser.tab.cc PROPERTIES COMPILE_FLAGS "-Wno-conversion")
+ endif()
+ 
+-if (WITH_LLVM AND NOT ${LLVM_VERSION} VERSION_LESS "10.0.0")
+-    set_target_properties(symengine PROPERTIES CXX_STANDARD 14 CXX_EXTENSIONS OFF CXX_STANDARD_REQUIRED yes)
++if (WITH_LLVM)
++    if (NOT ${LLVM_VERSION} VERSION_LESS "16.0.0")
++        set_target_properties(symengine PROPERTIES CXX_STANDARD 17 CXX_EXTENSIONS OFF CXX_STANDARD_REQUIRED yes)
++    elseif (NOT ${LLVM_VERSION} VERSION_LESS "10.0.0")
++        set_target_properties(symengine PROPERTIES CXX_STANDARD 14 CXX_EXTENSIONS OFF CXX_STANDARD_REQUIRED yes)
++    endif()
+ endif()
+ 
+ if (WITH_SYMENGINE_TEUCHOS)
+diff --git a/libsymengine/symengine/llvm_double.cpp b/libsymengine/symengine/llvm_double.cpp
+index a4e71901a..d6f5a41fe 100644
+--- a/libsymengine/symengine/llvm_double.cpp
++++ b/libsymengine/symengine/llvm_double.cpp
+@@ -632,7 +632,11 @@ void LLVMVisitor::bvisit(const Piecewise &x)
+     then_bb = builder->GetInsertBlock();
+ 
+     // Emit else block.
++#if (LLVM_VERSION_MAJOR < 16)
+     function->getBasicBlockList().push_back(else_bb);
++#else
++    function->insert(function->end(), else_bb);
++#endif
+     builder->SetInsertPoint(else_bb);
+     llvm::Value *else_value = apply(*pw->get_vec().back().first);
+     builder->CreateBr(merge_bb);
+@@ -642,7 +646,11 @@ void LLVMVisitor::bvisit(const Piecewise &x)
+     else_bb = builder->GetInsertBlock();
+ 
+     // Emit merge block.
++#if (LLVM_VERSION_MAJOR < 16)
+     function->getBasicBlockList().push_back(merge_bb);
++#else
++    function->insert(function->end(), merge_bb);
++#endif
+     builder->SetInsertPoint(merge_bb);
+     llvm::PHINode *phi_node
+         = builder->CreatePHI(get_float_type(&mod->getContext()), 2);
+-- 
+2.47.0

--- a/overrides/patches/symengine-0.9.2/0104-use-new-llvm-pass-manager-instead-of-legacy-pass-man.patch
+++ b/overrides/patches/symengine-0.9.2/0104-use-new-llvm-pass-manager-instead-of-legacy-pass-man.patch
@@ -1,0 +1,283 @@
+From bbea0f4035a2bbc1be821549fb15e81fb36ec623 Mon Sep 17 00:00:00 2001
+From: Liam Keegan <liam@keegan.ch>
+Date: Sun, 21 Mar 2021 15:11:00 +0100
+Subject: [PATCH] use new llvm pass manager instead of legacy pass manager
+
+- use PassBuilder default -Ox passes instead of manually specifying passes
+- remove LLVMVisitor::init() overloads with explicit list of passes
+- add `passes` to SYMENGINE_LLVM_COMPONENTS in CMakeLists
+- increase minimum required llvm version to 4.0
+- remove llvm from USE_GLIBCXX_DEBUG ci job
+  - using debug libstdc++ changes the ABI: https://gcc.gnu.org/onlinedocs/libstdc++/manual/debug_mode_using.html
+  - but llvm library is not compiled against debug libstdc++
+  - vector is passed between debug and non-debug translation units -> crash
+---
+  CMakeLists.txt                              |   4 +-
+ symengine/llvm_double.cpp                   | 126 +++++++-------------
+ symengine/llvm_double.h                     |  13 +-
+ symengine/tests/eval/test_lambda_double.cpp |   3 +-
+ 6 files changed, 47 insertions(+), 103 deletions(-)
+
+ddiff --git a/CMakeLists.txt b/CMakeLists.txt
+index 27b0f9af9..220afc8c2 100644
+--- a/libsymengine/CMakeLists.txt
++++ b/libsymengine/CMakeLists.txt
+@@ -399,9 +399,9 @@ set(WITH_LLVM no
+     CACHE BOOL "Build with LLVM")
+ 
+ if (WITH_LLVM)
+-    set(SYMENGINE_LLVM_COMPONENTS asmparser core executionengine instcombine mcjit native nativecodegen scalaropts vectorize support transformutils)
++    set(SYMENGINE_LLVM_COMPONENTS asmparser core executionengine instcombine mcjit native nativecodegen scalaropts vectorize support transformutils passes)
+     find_package(LLVM REQUIRED ${SYMENGINE_LLVM_COMPONENTS})
+-    set(LLVM_MINIMUM_REQUIRED_VERSION "3.8")
++    set(LLVM_MINIMUM_REQUIRED_VERSION "4.0")
+     if (LLVM_PACKAGE_VERSION LESS ${LLVM_MINIMUM_REQUIRED_VERSION})
+ 	    message(FATAL_ERROR "LLVM version found ${LLVM_PACKAGE_VERSION} is too old.
+                              Require at least ${LLVM_MINIMUM_REQUIRED_VERSION}")
+diff --git a/libsymengine/symengine/llvm_double.cpp b/libsymengine/symengine/llvm_double.cpp
+index d6f5a41fe..4911b4c78 100644
+--- a/libsymengine/symengine/llvm_double.cpp
++++ b/libsymengine/symengine/llvm_double.cpp
+@@ -1,8 +1,8 @@
+ #include "llvm/ADT/STLExtras.h"
+-#include "llvm/Analysis/Passes.h"
+ #include "llvm/ExecutionEngine/ExecutionEngine.h"
+ #include "llvm/ExecutionEngine/GenericValue.h"
+ #include "llvm/ExecutionEngine/MCJIT.h"
++#include "llvm/Passes/PassBuilder.h"
+ #include "llvm/IR/Argument.h"
+ #include "llvm/IR/Attributes.h"
+ #include "llvm/IR/BasicBlock.h"
+@@ -12,7 +12,7 @@
+ #include "llvm/IR/IRBuilder.h"
+ #include "llvm/IR/Instructions.h"
+ #include "llvm/IR/Intrinsics.h"
+-#include "llvm/IR/LegacyPassManager.h"
++#include "llvm/Analysis/Passes.h"
+ #include "llvm/IR/LLVMContext.h"
+ #include "llvm/IR/Module.h"
+ #include "llvm/IR/Type.h"
+@@ -25,8 +25,6 @@
+ #include "llvm/IR/Verifier.h"
+ #include "llvm/Support/TargetSelect.h"
+ #include "llvm/Target/TargetMachine.h"
+-#include "llvm/Transforms/Scalar.h"
+-#include "llvm/Transforms/Vectorize.h"
+ #include "llvm/ExecutionEngine/ObjectCache.h"
+ #include "llvm/Support/FileSystem.h"
+ #include "llvm/Support/Path.h"
+@@ -36,17 +34,6 @@
+ #include <vector>
+ #include <fstream>
+ 
+-#if (LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 9)                       \
+-    || (LLVM_VERSION_MAJOR > 3)
+-#include <llvm/Transforms/Scalar/GVN.h>
+-#endif
+-
+-#if (LLVM_VERSION_MAJOR >= 7)
+-#include <llvm/Transforms/InstCombine/InstCombine.h>
+-#include <llvm/Transforms/Scalar/InstSimplifyPass.h>
+-#include <llvm/Transforms/Utils.h>
+-#endif
+-
+ #include <symengine/llvm_double.h>
+ #include <symengine/eval_double.h>
+ #include <symengine/eval.h>
+@@ -73,15 +60,7 @@ llvm::Value *LLVMVisitor::apply(const Basic &b)
+ void LLVMVisitor::init(const vec_basic &x, const Basic &b, bool symbolic_cse,
+                        unsigned opt_level)
+ {
+-    init(x, b, symbolic_cse, LLVMVisitor::create_default_passes(opt_level),
+-         opt_level);
+-}
+-
+-void LLVMVisitor::init(const vec_basic &x, const Basic &b, bool symbolic_cse,
+-                       const std::vector<llvm::Pass *> &passes,
+-                       unsigned opt_level)
+-{
+-    init(x, {b.rcp_from_this()}, symbolic_cse, passes, opt_level);
++    init(x, {b.rcp_from_this()}, symbolic_cse, opt_level);
+ }
+ 
+ llvm::Function *LLVMVisitor::get_function_type(llvm::LLVMContext *context)
+@@ -140,58 +119,8 @@ llvm::Function *LLVMVisitor::get_function_type(llvm::LLVMContext *context)
+     return F;
+ }
+ 
+-std::vector<llvm::Pass *> LLVMVisitor::create_default_passes(int optlevel)
+-{
+-    std::vector<llvm::Pass *> passes;
+-    if (optlevel == 0) {
+-        return passes;
+-    }
+-#if (LLVM_VERSION_MAJOR < 4)
+-    passes.push_back(llvm::createInstructionCombiningPass());
+-#else
+-    passes.push_back(llvm::createInstructionCombiningPass(optlevel > 1));
+-#endif
+-    passes.push_back(llvm::createDeadCodeEliminationPass());
+-    passes.push_back(llvm::createPromoteMemoryToRegisterPass());
+-    passes.push_back(llvm::createReassociatePass());
+-    passes.push_back(llvm::createGVNPass());
+-    passes.push_back(llvm::createCFGSimplificationPass());
+-    passes.push_back(llvm::createPartiallyInlineLibCallsPass());
+-#if (LLVM_VERSION_MAJOR < 5)
+-    passes.push_back(llvm::createLoadCombinePass());
+-#endif
+-#if LLVM_VERSION_MAJOR >= 7
+-    passes.push_back(llvm::createInstSimplifyLegacyPass());
+-#else
+-    passes.push_back(llvm::createInstructionSimplifierPass());
+-#endif
+-    passes.push_back(llvm::createMemCpyOptPass());
+-    passes.push_back(llvm::createSROAPass());
+-    passes.push_back(llvm::createMergedLoadStoreMotionPass());
+-    passes.push_back(llvm::createBitTrackingDCEPass());
+-    passes.push_back(llvm::createAggressiveDCEPass());
+-    if (optlevel > 2) {
+-        passes.push_back(llvm::createSLPVectorizerPass());
+-#if LLVM_VERSION_MAJOR >= 7
+-        passes.push_back(llvm::createInstSimplifyLegacyPass());
+-#else
+-        passes.push_back(llvm::createInstructionSimplifierPass());
+-#endif
+-    }
+-    return passes;
+-}
+-
+ void LLVMVisitor::init(const vec_basic &inputs, const vec_basic &outputs,
+                        const bool symbolic_cse, unsigned opt_level)
+-{
+-    init(inputs, outputs, symbolic_cse,
+-         LLVMVisitor::create_default_passes(opt_level), opt_level);
+-}
+-
+-void LLVMVisitor::init(const vec_basic &inputs, const vec_basic &outputs,
+-                       const bool symbolic_cse,
+-                       const std::vector<llvm::Pass *> &passes,
+-                       unsigned opt_level)
+ {
+     executionengine.reset();
+     llvm::InitializeNativeTarget();
+@@ -206,13 +135,6 @@ void LLVMVisitor::init(const vec_basic &inputs, const vec_basic &outputs,
+     module->setDataLayout("");
+     mod = module.get();
+ 
+-    // Create a new pass manager attached to it.
+-    fpm = std::make_shared<llvm::legacy::FunctionPassManager>(mod);
+-    for (auto pass : passes) {
+-        fpm->add(pass);
+-    }
+-    fpm->doInitialization();
+-
+     auto F = get_function_type(context.get());
+ 
+     // Add a basic block to the function. As before, it automatically
+@@ -294,11 +216,47 @@ void LLVMVisitor::init(const vec_basic &inputs, const vec_basic &outputs,
+     //     module->print(llvm::errs(), nullptr);
+     // #endif
+ 
+-    // Optimize the function.
+-    fpm->run(*F);
++    // module->print(llvm::errs(), nullptr);
++
++    // Optimize the function using default passes from PassBuilder
++    // FunctionSimplificationPipeline for the opt_level
++#if (LLVM_VERSION_MAJOR < 14)
++    using OptimizationLevel = llvm::PassBuilder::OptimizationLevel;
++#else
++    using OptimizationLevel = llvm::OptimizationLevel;
++#endif
++    llvm::PassBuilder PB;
++    llvm::ModuleAnalysisManager MAM;
++    llvm::CGSCCAnalysisManager CGAM;
++    llvm::FunctionAnalysisManager FAM;
++    llvm::LoopAnalysisManager LAM;
++    PB.registerModuleAnalyses(MAM);
++    PB.registerCGSCCAnalyses(CGAM);
++    PB.registerFunctionAnalyses(FAM);
++    PB.registerLoopAnalyses(LAM);
++    PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
++    llvm::FunctionPassManager FPM;
++    OptimizationLevel pb_opt_level{OptimizationLevel::O3};
++    if (opt_level == 0) {
++        pb_opt_level = OptimizationLevel::O0;
++    } else if (opt_level == 1) {
++        pb_opt_level = OptimizationLevel::O1;
++    } else if (opt_level == 2) {
++        pb_opt_level = OptimizationLevel::O2;
++    }
++#if (LLVM_VERSION_MAJOR < 6)
++    FPM = PB.buildFunctionSimplificationPipeline(pb_opt_level);
++#elif (LLVM_VERSION_MAJOR < 12)
++    FPM = PB.buildFunctionSimplificationPipeline(
++        pb_opt_level, llvm::PassBuilder::ThinLTOPhase::None);
++#else
++    FPM = PB.buildFunctionSimplificationPipeline(
++        pb_opt_level, llvm::ThinOrFullLTOPhase::None);
++#endif
++    FPM.run(*F, FAM);
+ 
+     // std::cout << "Optimized LLVM IR" << std::endl;
+-    // module->dump();
++    // module->print(llvm::errs(), nullptr);
+ 
+     // Now we create the JIT.
+     std::string error;
+diff --git a/libsymengine/symengine/llvm_double.h b/libsymengine/symengine/llvm_double.h
+index 6ce4b9e57..9d64ebf8e 100644
+--- a/libsymengine/symengine/llvm_double.h
++++ b/libsymengine/symengine/llvm_double.h
+@@ -18,10 +18,6 @@ class ExecutionEngine;
+ class MemoryBufferRef;
+ class LLVMContext;
+ class Pass;
+-namespace legacy
+-{
+-class FunctionPassManager;
+-}
+ } // namespace llvm
+ 
+ namespace SymEngine
+@@ -39,7 +35,7 @@ protected:
+     llvm::Value *result_;
+     std::shared_ptr<llvm::LLVMContext> context;
+     std::shared_ptr<llvm::ExecutionEngine> executionengine;
+-    std::shared_ptr<llvm::legacy::FunctionPassManager> fpm;
++
+     intptr_t func;
+ 
+     // Following are invalid after the init call.
+@@ -53,15 +49,8 @@ public:
+     llvm::Value *apply(const Basic &b);
+     void init(const vec_basic &x, const Basic &b,
+               const bool symbolic_cse = false, unsigned opt_level = 3);
+-    void init(const vec_basic &x, const Basic &b, const bool symbolic_cse,
+-              const std::vector<llvm::Pass *> &passes, unsigned opt_level = 3);
+     void init(const vec_basic &inputs, const vec_basic &outputs,
+               const bool symbolic_cse = false, unsigned opt_level = 3);
+-    void init(const vec_basic &inputs, const vec_basic &outputs,
+-              const bool symbolic_cse, const std::vector<llvm::Pass *> &passes,
+-              unsigned opt_level = 3);
+-
+-    static std::vector<llvm::Pass *> create_default_passes(int optlevel);
+ 
+     // Helper functions
+     void set_double(double d);
+diff --git a/libsymengine/symengine/tests/eval/test_lambda_double.cpp b/libsymengine/symengine/tests/eval/test_lambda_double.cpp
+index 4389169a4..ae64e6dd4 100644
+--- a/libsymengine/symengine/tests/eval/test_lambda_double.cpp
++++ b/libsymengine/symengine/tests/eval/test_lambda_double.cpp
+@@ -520,8 +520,7 @@ TEST_CASE("Check that our default LLVM passes give correct results",
+     v.init({x, y, z}, *r);
+     LLVMDoubleVisitor v2;
+     for (int opt_level = 0; opt_level < 4; ++opt_level) {
+-        v2.init({x, y, z}, *r, false,
+-                LLVMDoubleVisitor::create_default_passes(opt_level), opt_level);
++        v2.init({x, y, z}, *r, false, opt_level);
+         d = v.call({0.4, 2.0, 3.0});
+         d2 = v2.call({0.4, 2.0, 3.0});
+         // Check for 12 digits with doubles
+-- 
+2.47.0

--- a/overrides/patches/torch-2.4.1/0001-Don-t-run-build_deps-for-dist_info.patch
+++ b/overrides/patches/torch-2.4.1/0001-Don-t-run-build_deps-for-dist_info.patch
@@ -1,0 +1,38 @@
+From ccadfd0062131cd0806418eff7aeb77759b0f285 Mon Sep 17 00:00:00 2001
+From: Joseph Groenenboom <jgroenen@redhat.com>
+Date: Thu, 26 Sep 2024 14:03:40 -0400
+Subject: [PATCH 1/3] Don't run build_deps() for dist_info
+
+Doesn't appear to be necessary, and was failing.
+
+Failure was:
+
+```
+$ python setup.py dist_info
+Building wheel torch-2.3.0
+WARNING setuptools_scm._integration.setuptools pyproject.toml does not contain a tool.setuptools_scm section
+-- Building version 2.3.0
+cmake3 --build . --target install --config Release
+No such file or directory
+CMake Error: Generator: execution of make failed. Make command was: /tmp/pip-build-env-cf5cyj9m/overlay/bin/ninja install &&
+```
+---
+ setup.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/setup.py b/setup.py
+index 499e0b06ef..2397d19e38 100644
+--- a/setup.py
++++ b/setup.py
+@@ -299,7 +299,7 @@ for i, arg in enumerate(sys.argv):
+         break
+     if arg == "-q" or arg == "--quiet":
+         VERBOSE_SCRIPT = False
+-    if arg in ["clean", "egg_info", "sdist"]:
++    if arg in ["clean", "egg_info", "dist_info", "sdist"]:
+         RUN_BUILD_DEPS = False
+     filtered_args.append(arg)
+ sys.argv = filtered_args
+-- 
+2.43.5
+

--- a/overrides/patches/torch-2.4.1/0003-Add-build-and-project-requirements.patch
+++ b/overrides/patches/torch-2.4.1/0003-Add-build-and-project-requirements.patch
@@ -1,0 +1,40 @@
+From 5040e19a881fa327f6ab2741b96cba8235d00254 Mon Sep 17 00:00:00 2001
+From: Joseph Groenenboom <jgroenen@redhat.com>
+Date: Thu, 26 Sep 2024 14:20:00 -0400
+Subject: [PATCH 3/3] Add build and project requirements.
+
+---
+ pyproject.toml   | 5 +++++
+ requirements.txt | 3 +++
+ 2 files changed, 8 insertions(+)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 24a917b808..07d42be8ad 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -9,6 +9,11 @@ requires = [
+     "cmake",
+     "typing-extensions",
+     "requests",
++    "filelock",
++    "iniconfig",
++    "packaging",
++    "pluggy",
++    "pybind11",
+ ]
+ # Use legacy backend to import local packages in setup.py
+ build-backend = "setuptools.build_meta:__legacy__"
+diff --git a/requirements.txt b/requirements.txt
+index cc1616a1d9..14c9ca6a71 100644
+--- a/requirements.txt
++++ b/requirements.txt
+@@ -20,3 +20,6 @@ ninja
+ setuptools ; python_version >= "3.12"
+ packaging
+ optree>=0.11.0
++iniconfig
++pluggy
++pybind11
+-- 
+2.43.5
+

--- a/overrides/patches/torch-2.4.1/0005-stop-six-download.patch
+++ b/overrides/patches/torch-2.4.1/0005-stop-six-download.patch
@@ -1,0 +1,12 @@
+diff --git a/third_party/NNPACK/CMakeLists.txt b/third_party/NNPACK/CMakeLists.txt
+--- a/third_party/NNPACK/CMakeLists.txt
++++ b/third_party/NNPACK/CMakeLists.txt
+@@ -15,6 +15,8 @@
+ SET(NNPACK_LIBRARY_TYPE "default" CACHE STRING "Type of library (shared, static, or default) to build")
+ SET_PROPERTY(CACHE NNPACK_LIBRARY_TYPE PROPERTY STRINGS default static shared)
+ OPTION(NNPACK_BUILD_TESTS "Build NNPACK unit tests" ON)
++SET(PYTHON_SIX_SOURCE_DIR "$ENV{GIT_REPOS_DIR}/six" CACHE STRING "six (Python package) source directory")
++
+ 
+ # ---[ CMake options
+ IF(NNPACK_BUILD_TESTS)

--- a/overrides/patches/torch-2.4.1/0006-Remove-CMake-check-to-keep-PyTorch-from-building-it.patch
+++ b/overrides/patches/torch-2.4.1/0006-Remove-CMake-check-to-keep-PyTorch-from-building-it.patch
@@ -1,0 +1,24 @@
+From a04f82fbca7004c90ad94ec4cd9e5f55e9b42cff Mon Sep 17 00:00:00 2001
+From: Joseph Groenenboom <jgroenen@redhat.com>
+Date: Mon, 14 Oct 2024 15:53:02 -0400
+Subject: [PATCH 5/5] Remove CMake check to keep PyTorch from building it
+
+---
+ pyproject.toml | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 07d42be8ad..6342d97c88 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -6,7 +6,6 @@ requires = [
+     "numpy",
+     "ninja",
+     "pyyaml",
+-    "cmake",
+     "typing-extensions",
+     "requests",
+     "filelock",
+-- 
+2.43.5
+

--- a/overrides/patches/torch-2.4.1/0007-fix-false-cmake-warnings.patch
+++ b/overrides/patches/torch-2.4.1/0007-fix-false-cmake-warnings.patch
@@ -1,0 +1,29 @@
+diff -urNp torch-2.3.1.orig/third_party/fbgemm/CMakeLists.txt torch-2.3.1/third_party/fbgemm/CMakeLists.txt
+--- torch-2.3.1.orig/third_party/fbgemm/CMakeLists.txt	2024-10-01 11:44:22.128474811 -0400
++++ torch-2.3.1/third_party/fbgemm/CMakeLists.txt	2024-10-01 11:45:23.859456212 -0400
+@@ -135,7 +135,7 @@ endif()
+ # Check if compiler supports OpenMP
+ find_package(OpenMP)
+ if (OpenMP_FOUND)
+-  message(WARNING "OpenMP found! OpenMP_C_INCLUDE_DIRS = ${OpenMP_C_INCLUDE_DIRS}")
++  message(STATUS "OpenMP found! OpenMP_C_INCLUDE_DIRS = ${OpenMP_C_INCLUDE_DIRS}")
+   include_directories(${OpenMP_C_INCLUDE_DIRS})
+   set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+@@ -229,11 +229,11 @@ if(USE_SANITIZER)
+     "-fsanitize=${USE_SANITIZER}" "-fno-omit-frame-pointer")
+ endif()
+ 
+-message(WARNING "==========")
+-message(WARNING "CMAKE_BUILD_TYPE = ${CMAKE_BUILD_TYPE}")
+-message(WARNING "CMAKE_CXX_FLAGS_DEBUG is ${CMAKE_CXX_FLAGS_DEBUG}")
+-message(WARNING "CMAKE_CXX_FLAGS_RELEASE is ${CMAKE_CXX_FLAGS_RELEASE}")
+-message(WARNING "==========")
++message(STATUS "==========")
++message(STATUS "CMAKE_BUILD_TYPE = ${CMAKE_BUILD_TYPE}")
++message(STATUS "CMAKE_CXX_FLAGS_DEBUG is ${CMAKE_CXX_FLAGS_DEBUG}")
++message(STATUS "CMAKE_CXX_FLAGS_RELEASE is ${CMAKE_CXX_FLAGS_RELEASE}")
++message(STATUS "==========")
+ 
+ if(NOT TARGET asmjit)
+   #Download asmjit from github if ASMJIT_SRC_DIR is not specified.

--- a/overrides/patches/torch-2.4.1/0007-use-aotriton-wheel.patch
+++ b/overrides/patches/torch-2.4.1/0007-use-aotriton-wheel.patch
@@ -1,0 +1,51 @@
+diff -urNp torch-2.4.1.orig/cmake/External/aotriton.cmake torch-2.4.1/cmake/External/aotriton.cmake
+--- torch-2.4.1.orig/cmake/External/aotriton.cmake	2024-11-07 19:44:46.578815765 -0500
++++ torch-2.4.1/cmake/External/aotriton.cmake	2024-11-07 19:45:23.554866020 -0500
+@@ -1,41 +1,19 @@
+ if(NOT __AOTRITON_INCLUDED)
+   set(__AOTRITON_INCLUDED TRUE)
+ 
+-  set(__AOTRITON_SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/aotriton/src")
+-  set(__AOTRITON_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/aotriton/build")
++  set(__AOTRITON_EXTERN_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/aotriton")
+   set(__AOTRITON_INSTALL_DIR "${PROJECT_SOURCE_DIR}/torch")
+   add_library(__caffe2_aotriton INTERFACE)
+   # Note it is INSTALL"ED"
+   if(DEFINED ENV{AOTRITON_INSTALLED_PREFIX})
++    install(DIRECTORY
++            $ENV{AOTRITON_INSTALLED_PREFIX}/lib
++            $ENV{AOTRITON_INSTALLED_PREFIX}/include
++            DESTINATION ${__AOTRITON_INSTALL_DIR})
+     set(__AOTRITON_INSTALL_DIR "$ENV{AOTRITON_INSTALLED_PREFIX}")
+     message(STATUS "Using Preinstalled AOTriton at ${__AOTRITON_INSTALL_DIR}")
+-  else()
+-    file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/.ci/docker/aotriton_version.txt" __AOTRITON_CI_INFO)
+-    list(GET __AOTRITON_CI_INFO 3 __AOTRITON_CI_COMMIT)
+-    ExternalProject_Add(aotriton_external
+-      GIT_REPOSITORY https://github.com/ROCm/aotriton.git
+-      GIT_TAG ${__AOTRITON_CI_COMMIT}
+-      SOURCE_DIR ${__AOTRITON_SOURCE_DIR}
+-      BINARY_DIR ${__AOTRITON_BUILD_DIR}
+-      PREFIX ${__AOTRITON_INSTALL_DIR}
+-      CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${__AOTRITON_INSTALL_DIR}
+-      -DAOTRITON_COMPRESS_KERNEL=OFF
+-      -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+-      -DAOTRITON_NO_PYTHON=ON
+-      -DAOTRITON_NO_SHARED=ON
+-      # CONFIGURE_COMMAND ""
+-      BUILD_COMMAND ""  # No build, install command will repeat the build process due to problems in the build system.
+-      BUILD_BYPRODUCTS "${__AOTRITON_INSTALL_DIR}/lib/libaotriton_v2.a"
+-      USES_TERMINAL_DOWNLOAD TRUE
+-      USES_TERMINAL_CONFIGURE TRUE
+-      USES_TERMINAL_BUILD TRUE
+-      USES_TERMINAL_INSTALL TRUE
+-      # INSTALL_COMMAND ${MAKE_COMMAND} install
+-      )
+-    add_dependencies(__caffe2_aotriton aotriton_external)
+-    message(STATUS "Using AOTriton compiled from source directory ${__AOTRITON_SOURCE_DIR}")
+   endif()
+-  target_link_libraries(__caffe2_aotriton INTERFACE ${__AOTRITON_INSTALL_DIR}/lib/libaotriton_v2.a)
++  target_link_libraries(__caffe2_aotriton INTERFACE ${__AOTRITON_INSTALL_DIR}/lib/libaotriton_v2.so)
+   target_include_directories(__caffe2_aotriton INTERFACE ${__AOTRITON_INSTALL_DIR}/include)
+   set(AOTRITON_FOUND TRUE)
+ endif() # __AOTRITON_INCLUDED

--- a/overrides/patches/torch-2.4.1/0009-set-AOTRITON_INSTALLED_PREFIX.patch
+++ b/overrides/patches/torch-2.4.1/0009-set-AOTRITON_INSTALLED_PREFIX.patch
@@ -1,0 +1,16 @@
+--- torch-2.4.1.orig/cmake/External/aotriton.cmake	2024-11-12 07:53:24.653033118 -0500
++++ torch-2.4.1/cmake/External/aotriton.cmake	2024-11-12 07:59:59.647472576 -0500
+@@ -5,6 +5,13 @@ if(NOT __AOTRITON_INCLUDED)
+   set(__AOTRITON_INSTALL_DIR "${PROJECT_SOURCE_DIR}/torch")
+   add_library(__caffe2_aotriton INTERFACE)
+   # Note it is INSTALL"ED"
++
++  execute_process(COMMAND python3 -c "import aotriton; import os; prefix, include = os.path.split(aotriton.get_aotriton_include()); print(prefix)"
++                  OUTPUT_VARIABLE __AOTRITON_INSTALLED_PREFIX)
++  string(STRIP ${__AOTRITON_INSTALLED_PREFIX} __AOTRITON_INSTALLED_PREFIX)
++  set(ENV{AOTRITON_INSTALLED_PREFIX} ${__AOTRITON_INSTALLED_PREFIX})
++  message("Setting AOTRITON_INSTALLED_PREFIX to: " $ENV{AOTRITON_INSTALLED_PREFIX})
++
+   if(DEFINED ENV{AOTRITON_INSTALLED_PREFIX})
+     install(DIRECTORY
+             $ENV{AOTRITON_INSTALLED_PREFIX}/lib

--- a/overrides/patches/torch-2.4.1/rocm-ubi9/0008-add-aotriton-runtime-dependency.patch
+++ b/overrides/patches/torch-2.4.1/rocm-ubi9/0008-add-aotriton-runtime-dependency.patch
@@ -1,0 +1,10 @@
+--- torch-2.4.1.orig/setup.py	2024-11-07 20:25:28.231973635 -0500
++++ torch-2.4.1/setup.py	2024-11-07 20:25:48.239158104 -0500
+@@ -1127,6 +1127,7 @@ def main():
+         "networkx",
+         "jinja2",
+         "fsspec",
++        "aotriton",
+     ]
+ 
+     if sys.version_info >= (3, 12, 0):

--- a/overrides/patches/torch-2.5.1/0001-Do-not-run-build_deps-for-dist_info.patch
+++ b/overrides/patches/torch-2.5.1/0001-Do-not-run-build_deps-for-dist_info.patch
@@ -1,0 +1,12 @@
+diff -ur a/setup.py b/setup.py
+--- a/setup.py
++++ b/setup.py
+@@ -299,7 +299,7 @@
+         break
+     if arg == "-q" or arg == "--quiet":
+         VERBOSE_SCRIPT = False
+-    if arg in ["clean", "egg_info", "sdist"]:
++    if arg in ["clean", "egg_info", "dist_info", "sdist"]:
+         RUN_BUILD_DEPS = False
+     filtered_args.append(arg)
+ sys.argv = filtered_args

--- a/overrides/patches/torch-2.5.1/0002-Add-build-and-project-requirements.patch
+++ b/overrides/patches/torch-2.5.1/0002-Add-build-and-project-requirements.patch
@@ -1,0 +1,11 @@
+diff --git a/requirements.txt b/requirements.txt
+--- a/requirements.txt
++++ b/requirements.txt
+@@ -22,3 +22,7 @@
+ ninja
+ packaging
+ optree>=0.12.0 ; python_version <= "3.12"
++iniconfig
++pluggy
++pybind11
++triton

--- a/overrides/patches/torch-2.5.1/0003-Stop-six-download.patch
+++ b/overrides/patches/torch-2.5.1/0003-Stop-six-download.patch
@@ -1,0 +1,11 @@
+diff --git a/third_party/NNPACK/CMakeLists.txt b/third_party/NNPACK/CMakeLists.txt
+--- a/third_party/NNPACK/CMakeLists.txt
++++ b/third_party/NNPACK/CMakeLists.txt
+@@ -15,6 +15,7 @@
+ SET(NNPACK_LIBRARY_TYPE "default" CACHE STRING "Type of library (shared, static, or default) to build")
+ SET_PROPERTY(CACHE NNPACK_LIBRARY_TYPE PROPERTY STRINGS default static shared)
+ OPTION(NNPACK_BUILD_TESTS "Build NNPACK unit tests" ON)
++SET(PYTHON_SIX_SOURCE_DIR "$ENV{GIT_REPOS_DIR}/six" CACHE STRING "six (Python package) source directory")
+ 
+ # ---[ CMake options
+ IF(NNPACK_BUILD_TESTS)

--- a/overrides/patches/triton-3.0.0/0001-Introduce-TRITON_OFFLINE_BUILD-4414.patch
+++ b/overrides/patches/triton-3.0.0/0001-Introduce-TRITON_OFFLINE_BUILD-4414.patch
@@ -1,0 +1,101 @@
+diff --git a/python/setup.py b/python/setup.py
+--- a/python/setup.py
++++ b/python/setup.py
+@@ -24,6 +24,8 @@
+ from setuptools.command.egg_info import egg_info
+ from wheel.bdist_wheel import bdist_wheel
+ 
++import pybind11
++
+ 
+ @dataclass
+ class Backend:
+@@ -111,6 +113,22 @@
+     return ""
+ 
+ 
++def is_offline_build() -> bool:
++    """
++    Downstream projects and distributions which bootstrap their own dependencies from scratch
++    and run builds in offline sandboxes
++    may set `TRITON_OFFLINE_BUILD` in the build environment to prevent any attempts at downloading
++    pinned dependencies from the internet or at using dependencies vendored in-tree.
++
++    Dependencies must be defined using respective search paths (cf. `syspath_var_name` in `Package`).
++    Missing dependencies lead to an early abortion.
++    Dependencies' compatibility is not verified.
++
++    Note that this flag isn't tested by the CI and does not provide any guarantees.
++    """
++    return check_env_flag("TRITON_OFFLINE_BUILD", "")
++
++
+ # --- third party packages -----
+ 
+ 
+@@ -216,8 +234,14 @@
+         if os.environ.get(p.syspath_var_name):
+             package_dir = os.environ[p.syspath_var_name]
+         version_file_path = os.path.join(package_dir, "version.txt")
+-        if p.syspath_var_name not in os.environ and\
+-           (not os.path.exists(version_file_path) or Path(version_file_path).read_text() != p.url):
++
++        input_defined = p.syspath_var_name in os.environ
++        input_exists = os.path.exists(version_file_path)
++        input_compatible = input_exists and Path(version_file_path).read_text() == p.url
++
++        if is_offline_build() and not input_defined:
++            raise RuntimeError(f"Requested an offline build but {p.syspath_var_name} is not set")
++        if not is_offline_build() and not input_defined and not input_compatible:
+             with contextlib.suppress(Exception):
+                 shutil.rmtree(package_root_dir)
+             os.makedirs(package_root_dir, exist_ok=True)
+@@ -241,6 +265,8 @@
+ 
+ 
+ def download_and_copy(name, src_path, variable, version, url_func):
++    if is_offline_build():
++        return
+     triton_cache_path = get_triton_cache_path()
+     if variable in os.environ:
+         return
+@@ -336,8 +362,17 @@
+         for ext in self.extensions:
+             self.build_extension(ext)
+ 
++    def get_pybind11_cmake_args(self):
++        pybind11_sys_path = get_env_with_keys(["PYBIND11_SYSPATH"])
++        if pybind11_sys_path:
++            pybind11_include_dir = os.path.join(pybind11_sys_path, "include")
++        else:
++            pybind11_include_dir = pybind11.get_include()
++        return [f"-DPYBIND11_INCLUDE_DIR={pybind11_include_dir}"]
++
+     def get_proton_cmake_args(self):
+-        cmake_args = get_thirdparty_packages([get_json_package_info(), get_pybind11_package_info()])
++        cmake_args = get_thirdparty_packages([get_json_package_info()])
++        cmake_args += self.get_pybind11_cmake_args()
+         cupti_include_dir = get_env_with_keys(["CUPTI_INCLUDE_PATH"])
+         if cupti_include_dir == "":
+             cupti_include_dir = os.path.join(get_base_dir(), "third_party", "nvidia", "backend", "include")
+@@ -352,7 +387,8 @@
+         lit_dir = shutil.which('lit')
+         ninja_dir = shutil.which('ninja')
+         # lit is used by the test suite
+-        thirdparty_cmake_args = get_thirdparty_packages([get_pybind11_package_info(), get_llvm_package_info()])
++        thirdparty_cmake_args = get_thirdparty_packages([get_llvm_package_info()])
++        thirdparty_cmake_args += self.get_pybind11_cmake_args()
+         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.path)))
+         # create build directories
+         if not os.path.exists(self.build_temp):
+@@ -421,6 +457,10 @@
+         else:
+             cmake_args += ["-DTRITON_BUILD_PROTON=OFF"]
+ 
++        if is_offline_build():
++            # unit test builds fetch googletests from GitHub
++            cmake_args += ["-DTRITON_BUILD_UT=OFF"]
++
+         env = os.environ.copy()
+         cmake_dir = get_cmake_dir()
+         subprocess.check_call(["cmake", self.base_dir] + cmake_args, cwd=cmake_dir, env=env)

--- a/overrides/patches/triton-3.0.0/0002-Locate-ptax-cuobjdump-nvdisasm-in-PATH-CUDA_HOME-bin.patch
+++ b/overrides/patches/triton-3.0.0/0002-Locate-ptax-cuobjdump-nvdisasm-in-PATH-CUDA_HOME-bin.patch
@@ -1,0 +1,41 @@
+diff --git a/python/triton/backends/compiler.py b/python/triton/backends/compiler.py
+--- a/python/triton/backends/compiler.py
++++ b/python/triton/backends/compiler.py
+@@ -1,5 +1,6 @@
+ import os
+ import re
++import shutil
+ import subprocess
+ 
+ from abc import ABCMeta, abstractmethod, abstractclassmethod
+@@ -27,6 +28,9 @@
+         base_dir = os.path.join(os.path.dirname(__file__), os.pardir)
+         paths = [
+             os.environ.get(f"TRITON_{binary.upper()}_PATH", ""),
++            os.path.join(os.environ.get("CUDA_HOME", "/usr/local/cuda"), "bin", binary),
++            os.path.join(os.environ.get("ROCM_PATH", "/opt/rocm"), "bin", binary),
++            shutil.which(binary) or "",
+             os.path.join(base_dir, "third_party", "cuda", "bin", binary),
+         ]
+         for p in paths:
+diff --git a/third_party/nvidia/backend/compiler.py b/third_party/nvidia/backend/compiler.py
+--- a/third_party/nvidia/backend/compiler.py
++++ b/third_party/nvidia/backend/compiler.py
+@@ -7,6 +7,7 @@
+ import hashlib
+ import re
+ import tempfile
++import shutil
+ import signal
+ import os
+ import subprocess
+@@ -17,6 +18,9 @@
+ def _path_to_binary(binary: str):
+     paths = [
+         os.environ.get(f"TRITON_{binary.upper()}_PATH", ""),
++        os.path.join(os.environ.get("CUDA_HOME", "/usr/local/cuda"), "bin", binary),
++        os.path.join(os.environ.get("ROCM_PATH", "/opt/rocm"), "bin", binary),
++        shutil.which(binary) or "",
+         os.path.join(os.path.dirname(__file__), "bin", binary),
+     ]
+ 

--- a/overrides/patches/triton-3.0.0/0003-Fix-check-for-proton.patch
+++ b/overrides/patches/triton-3.0.0/0003-Fix-check-for-proton.patch
@@ -1,0 +1,13 @@
+diff --git a/python/setup.py b/python/setup.py
+--- a/python/setup.py
++++ b/python/setup.py
+@@ -592,7 +592,8 @@
+         "triton/tools",
+     ]
+     packages += [f'triton/backends/{backend.name}' for backend in backends]
+-    packages += ["triton/profiler"]
++    if check_env_flag("TRITON_BUILD_PROTON", "ON"):  # Default ON
++        packages += ["triton/profiler"]
+     return packages
+ 
+ 

--- a/overrides/patches/triton-3.0.0/0004-Use-llvm-from-LLVM_SYSPATH.patch
+++ b/overrides/patches/triton-3.0.0/0004-Use-llvm-from-LLVM_SYSPATH.patch
@@ -1,0 +1,17 @@
+diff --git a/python/setup.py b/python/setup.py
+--- a/python/setup.py
++++ b/python/setup.py
+@@ -149,6 +149,13 @@
+ 
+ # llvm
+ def get_llvm_package_info():
++    llvm_syspath = get_env_with_keys("LLVM_SYSPATH")
++    if llvm_syspath:
++        print(
++            f"User specified LLVM_SYSPATH environment variable. Using pre-compiled LLVM at {llvm_syspath}"
++        )
++        return (Package("llvm", "LLVM-C.lib", "", f"{llvm_syspath}/include", f"{llvm_syspath}/lib", llvm_syspath))
++
+     system = platform.system()
+     try:
+         arch = {"x86_64": "x64", "arm64": "arm64", "aarch64": "arm64"}[platform.machine()]

--- a/overrides/patches/triton-3.1.0/0001-Introduce-TRITON_OFFLINE_BUILD-4414.patch
+++ b/overrides/patches/triton-3.1.0/0001-Introduce-TRITON_OFFLINE_BUILD-4414.patch
@@ -1,0 +1,100 @@
+diff --git a/python/setup.py b/python/setup.py
+--- a/python/setup.py
++++ b/python/setup.py
+@@ -24,6 +24,8 @@
+ from setuptools.command.egg_info import egg_info
+ from wheel.bdist_wheel import bdist_wheel
+ 
++import pybind11
++
+ 
+ @dataclass
+ class Backend:
+@@ -111,6 +113,22 @@
+     return ""
+ 
+ 
++def is_offline_build() -> bool:
++    """
++    Downstream projects and distributions which bootstrap their own dependencies from scratch
++    and run builds in offline sandboxes
++    may set `TRITON_OFFLINE_BUILD` in the build environment to prevent any attempts at downloading
++    pinned dependencies from the internet or at using dependencies vendored in-tree.
++
++    Dependencies must be defined using respective search paths (cf. `syspath_var_name` in `Package`).
++    Missing dependencies lead to an early abortion.
++    Dependencies' compatibility is not verified.
++
++    Note that this flag isn't tested by the CI and does not provide any guarantees.
++    """
++    return check_env_flag("TRITON_OFFLINE_BUILD", "")
++
++
+ # --- third party packages -----
+ 
+ 
+@@ -216,8 +234,13 @@
+         if os.environ.get(p.syspath_var_name):
+             package_dir = os.environ[p.syspath_var_name]
+         version_file_path = os.path.join(package_dir, "version.txt")
+-        if p.syspath_var_name not in os.environ and\
+-           (not os.path.exists(version_file_path) or Path(version_file_path).read_text() != p.url):
++        input_defined = p.syspath_var_name in os.environ
++        input_exists = os.path.exists(version_file_path)
++        input_compatible = input_exists and Path(version_file_path).read_text() == p.url
++
++        if is_offline_build() and not input_defined:
++            raise RuntimeError(f"Requested an offline build but {p.syspath_var_name} is not set")
++        if not is_offline_build() and not input_defined and not input_compatible:
+             with contextlib.suppress(Exception):
+                 shutil.rmtree(package_root_dir)
+             os.makedirs(package_root_dir, exist_ok=True)
+@@ -241,6 +264,8 @@
+ 
+ 
+ def download_and_copy(name, src_path, variable, version, url_func):
++    if is_offline_build():
++        return
+     triton_cache_path = get_triton_cache_path()
+     if variable in os.environ:
+         return
+@@ -336,8 +361,17 @@
+         for ext in self.extensions:
+             self.build_extension(ext)
+ 
++    def get_pybind11_cmake_args(self):
++        pybind11_sys_path = get_env_with_keys(["PYBIND11_SYSPATH"])
++        if pybind11_sys_path:
++            pybind11_include_dir = os.path.join(pybind11_sys_path, "include")
++        else:
++            pybind11_include_dir = pybind11.get_include()
++        return [f"-DPYBIND11_INCLUDE_DIR={pybind11_include_dir}"]
++
+     def get_proton_cmake_args(self):
+-        cmake_args = get_thirdparty_packages([get_json_package_info(), get_pybind11_package_info()])
++        cmake_args = get_thirdparty_packages([get_json_package_info()])
++        cmake_args += self.get_pybind11_cmake_args()
+         cupti_include_dir = get_env_with_keys(["CUPTI_INCLUDE_PATH"])
+         if cupti_include_dir == "":
+             cupti_include_dir = os.path.join(get_base_dir(), "third_party", "nvidia", "backend", "include")
+@@ -352,7 +386,8 @@
+         lit_dir = shutil.which('lit')
+         ninja_dir = shutil.which('ninja')
+         # lit is used by the test suite
+-        thirdparty_cmake_args = get_thirdparty_packages([get_pybind11_package_info(), get_llvm_package_info()])
++        thirdparty_cmake_args = get_thirdparty_packages([get_llvm_package_info()])
++        thirdparty_cmake_args += self.get_pybind11_cmake_args()
+         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.path)))
+         # create build directories
+         if not os.path.exists(self.build_temp):
+@@ -421,6 +456,10 @@
+         else:
+             cmake_args += ["-DTRITON_BUILD_PROTON=OFF"]
+ 
++        if is_offline_build():
++            # unit test builds fetch googletests from GitHub
++            cmake_args += ["-DTRITON_BUILD_UT=OFF"]
++
+         env = os.environ.copy()
+         cmake_dir = get_cmake_dir()
+         subprocess.check_call(["cmake", self.base_dir] + cmake_args, cwd=cmake_dir, env=env)

--- a/overrides/patches/triton-3.1.0/0002-Locate-ptax-cuobjdump-nvdisasm-in-PATH-CUDA_HOME-bin.patch
+++ b/overrides/patches/triton-3.1.0/0002-Locate-ptax-cuobjdump-nvdisasm-in-PATH-CUDA_HOME-bin.patch
@@ -1,0 +1,41 @@
+diff --git a/python/triton/backends/compiler.py b/python/triton/backends/compiler.py
+--- a/python/triton/backends/compiler.py
++++ b/python/triton/backends/compiler.py
+@@ -1,5 +1,6 @@
+ import os
+ import re
++import shutil
+ import subprocess
+ 
+ from abc import ABCMeta, abstractmethod, abstractclassmethod
+@@ -27,6 +28,9 @@
+         base_dir = os.path.join(os.path.dirname(__file__), os.pardir)
+         paths = [
+             os.environ.get(f"TRITON_{binary.upper()}_PATH", ""),
++            os.path.join(os.environ.get("CUDA_HOME", "/usr/local/cuda"), "bin", binary),
++            os.path.join(os.environ.get("ROCM_PATH", "/opt/rocm"), "bin", binary),
++            shutil.which(binary) or "",
+             os.path.join(base_dir, "third_party", "cuda", "bin", binary),
+         ]
+         for p in paths:
+diff --git a/third_party/nvidia/backend/compiler.py b/third_party/nvidia/backend/compiler.py
+--- a/third_party/nvidia/backend/compiler.py
++++ b/third_party/nvidia/backend/compiler.py
+@@ -7,6 +7,7 @@
+ import hashlib
+ import re
+ import tempfile
++import shutil
+ import signal
+ import os
+ import subprocess
+@@ -17,6 +18,9 @@
+ def _path_to_binary(binary: str):
+     paths = [
+         os.environ.get(f"TRITON_{binary.upper()}_PATH", ""),
++        os.path.join(os.environ.get("CUDA_HOME", "/usr/local/cuda"), "bin", binary),
++        os.path.join(os.environ.get("ROCM_PATH", "/opt/rocm"), "bin", binary),
++        shutil.which(binary) or "",
+         os.path.join(os.path.dirname(__file__), "bin", binary),
+     ]
+ 

--- a/overrides/patches/triton-3.1.0/0003-Fix-check-for-proton.patch
+++ b/overrides/patches/triton-3.1.0/0003-Fix-check-for-proton.patch
@@ -1,0 +1,13 @@
+diff --git a/python/setup.py b/python/setup.py
+--- a/python/setup.py
++++ b/python/setup.py
+@@ -599,7 +599,8 @@
+         "triton/tools",
+     ]
+     packages += [f'triton/backends/{backend.name}' for backend in backends]
+-    packages += ["triton/profiler"]
++    if check_env_flag("TRITON_BUILD_PROTON", "ON"):  # Default ON
++        packages += ["triton/profiler"]
+     return packages
+ 
+ 

--- a/overrides/patches/triton-3.1.0/0004-Use-llvm-from-LLVM_SYSPATH.patch
+++ b/overrides/patches/triton-3.1.0/0004-Use-llvm-from-LLVM_SYSPATH.patch
@@ -1,0 +1,17 @@
+diff --git a/python/setup.py b/python/setup.py
+--- a/python/setup.py
++++ b/python/setup.py
+@@ -159,6 +159,13 @@
+ 
+ # llvm
+ def get_llvm_package_info():
++    llvm_syspath = get_env_with_keys("LLVM_SYSPATH")
++    if llvm_syspath:
++        print(
++            f"User specified LLVM_SYSPATH environment variable. Using pre-compiled LLVM at {llvm_syspath}"
++        )
++        return (Package("llvm", "LLVM-C.lib", "", f"{llvm_syspath}/include", f"{llvm_syspath}/lib", llvm_syspath))
++
+     system = platform.system()
+     try:
+         arch = {"x86_64": "x64", "arm64": "arm64", "aarch64": "arm64"}[platform.machine()]

--- a/overrides/patches/vllm-0.6.2/cuda-ubi9/0001-Remove-cmake-build-requirement.patch
+++ b/overrides/patches/vllm-0.6.2/cuda-ubi9/0001-Remove-cmake-build-requirement.patch
@@ -1,0 +1,20 @@
+diff --git a/pyproject.toml b/pyproject.toml
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,7 +1,6 @@
+ [build-system]
+ # Should be mirrored in requirements-build.txt
+ requires = [
+-    "cmake>=3.26",
+     "ninja",
+     "packaging",
+     "setuptools>=61",
+diff --git a/requirements-build.txt b/requirements-build.txt
+--- a/requirements-build.txt
++++ b/requirements-build.txt
+@@ -1,5 +1,4 @@
+ # Should be mirrored in pyproject.toml
+-cmake>=3.26
+ ninja
+ packaging
+ setuptools>=61

--- a/overrides/patches/vllm-0.6.2/cuda-ubi9/0002-Force-torch-2.4.1-requirement.patch
+++ b/overrides/patches/vllm-0.6.2/cuda-ubi9/0002-Force-torch-2.4.1-requirement.patch
@@ -1,0 +1,57 @@
+diff --git a/pyproject.toml b/pyproject.toml
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -5,7 +5,7 @@
+     "packaging",
+     "setuptools>=61",
+     "setuptools-scm>=8.0",
+-    "torch == 2.4.0",
++    "torch == 2.4.1",
+     "wheel",
+     "jinja2",
+ ]
+diff --git a/requirements-build.txt b/requirements-build.txt
+--- a/requirements-build.txt
++++ b/requirements-build.txt
+@@ -3,6 +3,6 @@
+ packaging
+ setuptools>=61
+ setuptools-scm>=8
+-torch==2.4.0
++torch==2.4.1
+ wheel
+ jinja2
+diff --git a/requirements-cpu.txt b/requirements-cpu.txt
+--- a/requirements-cpu.txt
++++ b/requirements-cpu.txt
+@@ -2,5 +2,5 @@
+ -r requirements-common.txt
+ 
+ # Dependencies for x86_64 CPUs
+-torch == 2.4.0+cpu; platform_machine != "ppc64le"
++torch == 2.4.1+cpu; platform_machine != "ppc64le"
+ torchvision; platform_machine != "ppc64le"   # required for the image processor of phi3v, this must be updated alongside torch
+diff --git a/requirements-cuda.txt b/requirements-cuda.txt
+--- a/requirements-cuda.txt
++++ b/requirements-cuda.txt
+@@ -4,7 +4,7 @@
+ # Dependencies for NVIDIA GPUs
+ ray >= 2.9
+ nvidia-ml-py # for pynvml package
+-torch == 2.4.0
++torch == 2.4.1
+ # These must be updated alongside torch
+ torchvision == 0.19   # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
+ xformers == 0.0.27.post2; platform_system == 'Linux' and platform_machine == 'x86_64'  # Requires PyTorch 2.4.0
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -49,7 +49,7 @@
+ # requirements.txt files and should be kept consistent.  The ROCm torch
+ # versions are derived from Dockerfile.rocm
+ #
+-set(TORCH_SUPPORTED_VERSION_CUDA "2.4.0")
++set(TORCH_SUPPORTED_VERSION_CUDA "2.4.1")
+ set(TORCH_SUPPORTED_VERSION_ROCM "2.5.0")
+ 
+ #

--- a/overrides/patches/vllm-0.6.2/cuda-ubi9/0003-Remove-ray-dependency.patch
+++ b/overrides/patches/vllm-0.6.2/cuda-ubi9/0003-Remove-ray-dependency.patch
@@ -1,0 +1,35 @@
+diff --git a/requirements-cuda.txt b/requirements-cuda.txt
+--- a/requirements-cuda.txt
++++ b/requirements-cuda.txt
+@@ -2,7 +2,6 @@
+ -r requirements-common.txt
+ 
+ # Dependencies for NVIDIA GPUs
+-ray >= 2.9
+ nvidia-ml-py # for pynvml package
+ torch == 2.4.1
+ # These must be updated alongside torch
+diff --git a/requirements-rocm.txt b/requirements-rocm.txt
+--- a/requirements-rocm.txt
++++ b/requirements-rocm.txt
+@@ -5,7 +5,6 @@
+ awscli
+ boto3
+ botocore
+-ray >= 2.10.0
+ peft
+ pytest-asyncio
+-tensorizer>=2.9.0
+\ No newline at end of file
++tensorizer>=2.9.0
+diff --git a/requirements-test.txt b/requirements-test.txt
+--- a/requirements-test.txt
++++ b/requirements-test.txt
+@@ -14,7 +14,6 @@
+ opencv-python # required for video test
+ peft
+ requests
+-ray[adag]==2.35
+ sentence-transformers # required for embedding
+ soundfile # required for audio test
+ compressed-tensors==0.4.0 # required for compressed-tensors

--- a/overrides/patches/vllm-0.6.2/cuda-ubi9/0004-Remove-version-munging.patch
+++ b/overrides/patches/vllm-0.6.2/cuda-ubi9/0004-Remove-version-munging.patch
@@ -1,0 +1,17 @@
+diff --git a/setup.py b/setup.py
+--- a/setup.py
++++ b/setup.py
+@@ -354,6 +354,7 @@
+ 
+ 
+ def get_vllm_version() -> str:
++    return "0.6.2"
+     version = get_version(
+         write_to="vllm/_version.py",  # TODO: move this to pyproject.toml
+     )
+diff --git a/vllm/_version.py b/vllm/_version.py
+--- a/vllm/_version.py
++++ b/vllm/_version.py
+@@ -0,0 +1,2 @@
++__version__ = "0.6.2"
++__version_tuple__ = ("0", "6", "2")

--- a/overrides/patches/vllm-0.6.2/cuda-ubi9/0005-vllm-flash-attn-cuda-fix.patch
+++ b/overrides/patches/vllm-0.6.2/cuda-ubi9/0005-vllm-flash-attn-cuda-fix.patch
@@ -1,0 +1,20 @@
+diff --git a/setup.py b/setup.py
+--- a/setup.py
++++ b/setup.py
+@@ -424,16 +424,6 @@
+         requirements = _read_requirements("requirements-cuda.txt")
+     elif _is_cuda():
+         requirements = _read_requirements("requirements-cuda.txt")
+-        cuda_major, cuda_minor = torch.version.cuda.split(".")
+-        modified_requirements = []
+-        for req in requirements:
+-            if ("vllm-flash-attn" in req
+-                    and not (cuda_major == "12" and cuda_minor == "1")):
+-                # vllm-flash-attn is built only for CUDA 12.1.
+-                # Skip for other versions.
+-                continue
+-            modified_requirements.append(req)
+-        requirements = modified_requirements
+     elif _is_hip():
+         requirements = _read_requirements("requirements-rocm.txt")
+     elif _is_neuron():

--- a/overrides/patches/vllm-0.6.2/cuda-ubi9/0007-Add-triton-dependency.patch
+++ b/overrides/patches/vllm-0.6.2/cuda-ubi9/0007-Add-triton-dependency.patch
@@ -1,0 +1,19 @@
+diff --git a/requirements-cuda.txt b/requirements-cuda.txt
+--- a/requirements-cuda.txt
++++ b/requirements-cuda.txt
+@@ -5,6 +5,7 @@
+ ray >= 2.9
+ nvidia-ml-py # for pynvml package
+ torch == 2.4.1
++triton
+ # These must be updated alongside torch
+ torchvision == 0.19   # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
+ xformers == 0.0.27.post2; platform_system == 'Linux' and platform_machine == 'x86_64'  # Requires PyTorch 2.4.0
+diff --git a/requirements-rocm.txt b/requirements-rocm.txt
+--- a/requirements-rocm.txt
++++ b/requirements-rocm.txt
+@@ -8,3 +8,4 @@
+ peft
+ pytest-asyncio
+ tensorizer>=2.9.0
++triton

--- a/overrides/patches/vllm-0.6.2/cuda-ubi9/0008-stop-cutlass-download.patch
+++ b/overrides/patches/vllm-0.6.2/cuda-ubi9/0008-stop-cutlass-download.patch
@@ -1,0 +1,41 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+--- CMakeLists.txt.orig	2024-10-03 04:17:46.311040629 -0400
++++ CMakeLists.txt	2024-10-03 04:18:46.707702373 -0400
+@@ -204,24 +204,6 @@
+   "csrc/torch_bindings.cpp")
+ 
+ if(VLLM_GPU_LANG STREQUAL "CUDA")
+-  SET(CUTLASS_ENABLE_HEADERS_ONLY ON CACHE BOOL "Enable only the header library")
+-
+-  # Set CUTLASS_REVISION manually -- its revision detection doesn't work in this case.
+-  set(CUTLASS_REVISION "v3.5.1" CACHE STRING "CUTLASS revision to use")
+-
+-  FetchContent_Declare(
+-        cutlass
+-        GIT_REPOSITORY https://github.com/nvidia/cutlass.git
+-        GIT_TAG v3.5.1
+-        GIT_PROGRESS TRUE
+-
+-        # Speed up CUTLASS download by retrieving only the specified GIT_TAG instead of the history.
+-        # Important: If GIT_SHALLOW is enabled then GIT_TAG works only with branch names and tags.
+-        # So if the GIT_TAG above is updated to a commit hash, GIT_SHALLOW must be set to FALSE
+-        GIT_SHALLOW TRUE
+-  )
+-  FetchContent_MakeAvailable(cutlass)
+-
+   list(APPEND VLLM_EXT_SRC
+     "csrc/mamba/mamba_ssm/selective_scan_fwd.cu"
+     "csrc/mamba/causal_conv1d/causal_conv1d.cu"
+@@ -257,6 +239,10 @@
+   #
+   # Machete kernels
+ 
++  if (DEFINED ENV{CUTLASS_DIR})
++    set(CUTLASS_DIR "$ENV{CUTLASS_DIR}")
++  endif()
++
+   # The machete kernels only work on hopper and require CUDA 12.0 or later.
+   if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER 12.0)
+     #

--- a/overrides/patches/vllm-0.6.2/cuda-ubi9/0009-Add-flash_attn-dependency.patch
+++ b/overrides/patches/vllm-0.6.2/cuda-ubi9/0009-Add-flash_attn-dependency.patch
@@ -1,0 +1,10 @@
+diff --git a/requirements-rocm.txt b/requirements-rocm.txt
+--- a/requirements-rocm.txt
++++ b/requirements-rocm.txt
+@@ -8,5 +8,6 @@
+ peft
+ pytest-asyncio
+ tensorizer>=2.9.0
++flash_attn
+ triton
+ setuptools-scm>=8

--- a/overrides/patches/vllm-0.6.2/cuda-ubi9/0013-CUDA-Allow-cuDNN-and-cuSPARSELT.patch
+++ b/overrides/patches/vllm-0.6.2/cuda-ubi9/0013-CUDA-Allow-cuDNN-and-cuSPARSELT.patch
@@ -1,0 +1,23 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -125,6 +125,19 @@
+     message(WARNING "Pytorch version ${TORCH_SUPPORTED_VERSION_CUDA} "
+       "expected for CUDA build, saw ${Torch_VERSION} instead.")
+   endif()
++
++  if (DEFINED "$ENV{CAFFE2_USE_CUDNN}")
++    message(STATUS "Environment variable CAFFE2_USE_CUDNN is set to $ENV{CAFFE2_USE_CUDNN}")
++    set(CAFFE2_USE_CUDNN "$ENV{CAFFE2_USE_CUDNN}")
++    if (DEFINED "$ENV{CUDNN_ROOT_DIR}")
++      message(STATUS "Environment variable CUDNN_ROOT_DIR is set to $ENV{CUDNN_ROOT_DIR}")
++      set(CUDNN_ROOT_DIR "$ENV{CUDNN_ROOT_DIR}")
++    endif()
++    if (DEFINED "$ENV{CUSPARSELT_ROOT_DIR}")
++      message(STATUS "Environment variable CUSPARSELT_ROOT_DIR is set to $ENV{CUSPARSELT_ROOT_DIR}")
++      set(CUSPARSELT_ROOT_DIR "$ENV{CUSPARSELT_ROOT_DIR}")
++    endif()
++  endif()
+ elseif(HIP_FOUND)
+   set(VLLM_GPU_LANG "HIP")
+ 

--- a/overrides/patches/vllm-0.6.2/rocm-ubi9/0001-Do-not-build-CMake.patch
+++ b/overrides/patches/vllm-0.6.2/rocm-ubi9/0001-Do-not-build-CMake.patch
@@ -1,0 +1,36 @@
+From a60c927970e169b9f29bcbfb2a984ae2a1ce4ad7 Mon Sep 17 00:00:00 2001
+From: Joseph Groenenboom <jgroenen@redhat.com>
+Date: Mon, 14 Oct 2024 23:57:34 -0400
+Subject: [PATCH 1/4] Do not build CMake
+
+CMake is already in the build image.  Find out a way to get around this triggering.
+---
+ pyproject.toml         | 1 -
+ requirements-build.txt | 1 -
+ 2 files changed, 2 deletions(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index be049e6d..a6b3026e 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,7 +1,6 @@
+ [build-system]
+ # Should be mirrored in requirements-build.txt
+ requires = [
+-    "cmake>=3.26",
+     "ninja",
+     "packaging",
+     "setuptools>=61",
+diff --git a/requirements-build.txt b/requirements-build.txt
+index 6144a56d..75e5fde3 100644
+--- a/requirements-build.txt
++++ b/requirements-build.txt
+@@ -1,5 +1,4 @@
+ # Should be mirrored in pyproject.toml
+-cmake>=3.26
+ ninja
+ packaging
+ setuptools>=61
+-- 
+2.43.5
+

--- a/overrides/patches/vllm-0.6.2/rocm-ubi9/0002-Bump-PyTorch-commit-for-all-targets.patch
+++ b/overrides/patches/vllm-0.6.2/rocm-ubi9/0002-Bump-PyTorch-commit-for-all-targets.patch
@@ -1,0 +1,66 @@
+From 6fb440ca90ae4a8dd71dc9d0965baa5372671151 Mon Sep 17 00:00:00 2001
+From: Joseph Groenenboom <jgroenen@redhat.com>
+Date: Tue, 15 Oct 2024 00:42:28 -0400
+Subject: [PATCH 2/4] Bump PyTorch commit for all targets
+
+Bump commit to match Torch level for all supported InstructLab targets, up to Torch 2.4.1.
+---
+ pyproject.toml         | 2 +-
+ requirements-build.txt | 2 +-
+ requirements-cpu.txt   | 2 +-
+ requirements-cuda.txt  | 4 ++--
+ 4 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index a6b3026e..f46cdc8e 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -5,7 +5,7 @@ requires = [
+     "packaging",
+     "setuptools>=61",
+     "setuptools-scm>=8.0",
+-    "torch == 2.4.0",
++    "torch == 2.4.1",
+     "wheel",
+     "jinja2",
+ ]
+diff --git a/requirements-build.txt b/requirements-build.txt
+index 75e5fde3..0f266a5a 100644
+--- a/requirements-build.txt
++++ b/requirements-build.txt
+@@ -3,6 +3,6 @@ ninja
+ packaging
+ setuptools>=61
+ setuptools-scm>=8
+-torch==2.4.0
++torch==2.4.1
+ wheel
+ jinja2
+diff --git a/requirements-cpu.txt b/requirements-cpu.txt
+index 27ca8ca5..61755e38 100644
+--- a/requirements-cpu.txt
++++ b/requirements-cpu.txt
+@@ -2,5 +2,5 @@
+ -r requirements-common.txt
+ 
+ # Dependencies for x86_64 CPUs
+-torch == 2.4.0+cpu; platform_machine != "ppc64le"
++torch == 2.4.1+cpu; platform_machine != "ppc64le"
+ torchvision; platform_machine != "ppc64le"   # required for the image processor of phi3v, this must be updated alongside torch
+diff --git a/requirements-cuda.txt b/requirements-cuda.txt
+index 3b3c2f87..9b31f4d0 100644
+--- a/requirements-cuda.txt
++++ b/requirements-cuda.txt
+@@ -4,7 +4,7 @@
+ # Dependencies for NVIDIA GPUs
+ ray >= 2.9
+ nvidia-ml-py # for pynvml package
+-torch == 2.4.0
++torch == 2.4.1
+ # These must be updated alongside torch
+ torchvision == 0.19   # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
+-xformers == 0.0.27.post2; platform_system == 'Linux' and platform_machine == 'x86_64'  # Requires PyTorch 2.4.0
++xformers == 0.0.27.post2; platform_system == 'Linux' and platform_machine == 'x86_64'  # Requires PyTorch 2.4.1
+-- 
+2.43.5
+

--- a/overrides/patches/vllm-0.6.2/rocm-ubi9/0003-Remove-Ray-for-ROCm-and-testing.patch
+++ b/overrides/patches/vllm-0.6.2/rocm-ubi9/0003-Remove-Ray-for-ROCm-and-testing.patch
@@ -1,0 +1,41 @@
+From 872a87752a21261358847c77ac30c633902704b5 Mon Sep 17 00:00:00 2001
+From: Joseph Groenenboom <jgroenen@redhat.com>
+Date: Tue, 15 Oct 2024 00:51:37 -0400
+Subject: [PATCH 3/4] Remove Ray for ROCm and testing
+
+Unsused for ROCm target.
+---
+ requirements-rocm.txt | 3 +--
+ requirements-test.txt | 1 -
+ 2 files changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/requirements-rocm.txt b/requirements-rocm.txt
+index 9e3c4a86..cb613264 100644
+--- a/requirements-rocm.txt
++++ b/requirements-rocm.txt
+@@ -5,8 +5,7 @@
+ awscli
+ boto3
+ botocore
+-ray >= 2.10.0
+ peft
+ pytest-asyncio
+ tensorizer>=2.9.0
+-setuptools-scm>=8
+\ No newline at end of file
++setuptools-scm>=8
+diff --git a/requirements-test.txt b/requirements-test.txt
+index 9c6fadb8..06b70731 100644
+--- a/requirements-test.txt
++++ b/requirements-test.txt
+@@ -14,7 +14,6 @@ librosa # required for audio test
+ opencv-python # required for video test
+ peft
+ requests
+-ray[adag]==2.35
+ sentence-transformers # required for embedding
+ soundfile # required for audio test
+ compressed-tensors==0.4.0 # required for compressed-tensors
+-- 
+2.43.5
+

--- a/overrides/patches/vllm-0.6.2/rocm-ubi9/0004-Remove-download-from-build.patch
+++ b/overrides/patches/vllm-0.6.2/rocm-ubi9/0004-Remove-download-from-build.patch
@@ -1,0 +1,59 @@
+From 4450530803e7ba1dea0153ef81ad2198f80c991f Mon Sep 17 00:00:00 2001
+From: Joseph Groenenboom <jgroenen@redhat.com>
+Date: Tue, 15 Oct 2024 16:26:46 -0400
+Subject: [PATCH 4/4] Remove download from build
+
+Allow the build to skip scm/git checkouts and build as it did in v0.6.1.
+
+Specify target version name so we can correctly build the version of vLLM we need.
+
+Below we set __version__ as part of the build workaround. This may be changed in the 
+future but for now it allows us to get around a check that used to be used to stage a
+checkout but we still want to use a tarball.
+---
+ setup.py        | 15 ++++++++++++---
+ vllm/version.py |  2 +-
+ 2 files changed, 13 insertions(+), 4 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index 8ef759f5..f6f1830b 100644
+--- a/setup.py
++++ b/setup.py
+@@ -352,11 +352,20 @@ def get_nvcc_cuda_version() -> Version:
+ def get_path(*filepath) -> str:
+     return os.path.join(ROOT_DIR, *filepath)
+ 
++def find_version(filepath: str) -> str:
++    """Extract version information from the given filepath.
++
++    Adapted from https://github.com/ray-project/ray/blob/0b190ee1160eeca9796bc091e07eaebf4c85b511/python/setup.py
++    """
++    with open(filepath) as fp:
++        version_match = re.search(r"__version__ = ['\"]([^'\"]*)['\"]",
++                                  fp.read(), re.M)
++        if version_match:
++            return version_match.group(1)
++        raise RuntimeError("Unable to find version string.")
+ 
+ def get_vllm_version() -> str:
+-    version = get_version(
+-        write_to="vllm/_version.py",  # TODO: move this to pyproject.toml
+-    )
++    version = find_version(get_path("vllm", "version.py"))
+ 
+     sep = "+" if "+" not in version else "."  # dev versions might contain +
+ 
+diff --git a/vllm/version.py b/vllm/version.py
+index 66e189dc..b8ee1735 100644
+--- a/vllm/version.py
++++ b/vllm/version.py
+@@ -7,5 +7,5 @@ except Exception as e:
+                   RuntimeWarning,
+                   stacklevel=2)
+ 
+-    __version__ = "dev"
++    __version__ = "0.6.2"
+     __version_tuple__ = (0, 0, __version__)
+-- 
+2.43.5
+

--- a/overrides/patches/vllm-0.6.2/rocm-ubi9/0005-ROCm-Make-rpdTracerControl-optional.patch
+++ b/overrides/patches/vllm-0.6.2/rocm-ubi9/0005-ROCm-Make-rpdTracerControl-optional.patch
@@ -1,0 +1,136 @@
+From: Fabien Dupont <fdupont@redhat.com>
+Date: Wed, 2 Oct 2024 11:16:41 +0200
+Subject: Make rpdtracer import only when required
+
+Patch to make RPD imports optional
+Original PR: https://github.com/ROCm/vllm/pull/216
+
+Co-authored-by: Rohan Potdar <rohan.potdar@amd.com>
+Signed-off-by: Fabien Dupont <fdupont@redhat.com>
+---
+ benchmarks/profiling/benchmark_latency.py    | 1-,1+
+ benchmarks/profiling/benchmark_throughput.py | 1-,1+
+ vllm/utils.py                                | 10-,24+
+ vllm/worker/worker.py                        | 1-,2+
+ 4 files changed, 13 deletions(-), 28 insertion(+)
+
+diff --git a/benchmarks/profiling/benchmark_latency.py b/benchmarks/profiling/benchmark_latency.py
+--- a/benchmarks/profiling/benchmark_latency.py
++++ b/benchmarks/profiling/benchmark_latency.py
+@@ -9,7 +9,6 @@
+ 
+ import numpy as np
+ import torch
+-from rpdTracerControl import rpdTracerControl as rpd
+ from tqdm import tqdm
+ 
+ from vllm import LLM, SamplingParams
+@@ -24,6 +23,7 @@
+ 
+     @contextmanager
+     def rpd_profiler_context():
++        from rpdTracerControl import rpdTracerControl as rpd
+         llm.start_profile()
+         yield
+         llm.stop_profile()
+diff --git a/benchmarks/profiling/benchmark_throughput.py b/benchmarks/profiling/benchmark_throughput.py
+--- a/benchmarks/profiling/benchmark_throughput.py
++++ b/benchmarks/profiling/benchmark_throughput.py
+@@ -9,7 +9,6 @@
+ 
+ import torch
+ import uvloop
+-from rpdTracerControl import rpdTracerControl as rpd
+ from tqdm import tqdm
+ from transformers import (AutoModelForCausalLM, AutoTokenizer,
+                           PreTrainedTokenizerBase)
+@@ -98,6 +97,7 @@
+ 
+     @contextmanager
+     def rpd_profiler_context():
++        from rpdTracerControl import rpdTracerControl as rpd
+         llm.start_profile()
+         yield
+         llm.stop_profile()
+diff --git a/vllm/utils.py b/vllm/utils.py
+--- a/vllm/utils.py
++++ b/vllm/utils.py
+@@ -31,7 +31,6 @@
+ import torch.types
+ import yaml
+ from packaging.version import Version
+-from rpdTracerControl import rpdTracerControl
+ from typing_extensions import ParamSpec, TypeIs, assert_never
+ 
+ import vllm.envs as envs
+@@ -208,6 +207,7 @@
+ 
+     def initialize_rpd_tracer(self, filename, nvtx):
+         try:
++            from rpdTracerControl import rpdTracerControl
+             rpd_trace.setup_environment_variables(filename)
+             rpdTracerControl.setFilename(name=filename, append=True)
+             return rpdTracerControl(nvtx=nvtx)
+@@ -233,21 +233,35 @@
+             print(f"An error occurred while creating the filename: {e}")
+ 
+ 
++@lru_cache(maxsize=None)
++def is_hipScopedMarker_available():
++
++    try:
++        from hipScopedMarker import hipScopedMarker
++    except ImportError:
++        hipScopedMarker = None
++    return hipScopedMarker is not None
++
++
+ class rpd_mark():
+ 
+     def __init__(self, name=None):
+         self.name = name
+ 
+     def __call__(self, func):
+-        from hipScopedMarker import hipScopedMarker
++        if is_hipScopedMarker_available():
++            from hipScopedMarker import hipScopedMarker
+ 
+-        @wraps(func)
+-        def inner(*args, **kwds):
+-            marker_name = self.name if self.name else f"{func.__name__}"
+-            with hipScopedMarker(f"{marker_name}"):
+-                return func(*args, **kwds)
++            @wraps(func)
++            def inner(*args, **kwds):
++                marker_name = self.name if self.name else f"{func.__name__}"
++                with hipScopedMarker(f"{marker_name}"):
++                    return func(*args, **kwds)
++
++            return inner
+ 
+-        return inner
++        else:
++            return func
+ 
+ 
+ class Device(enum.Enum):
+diff --git a/vllm/worker/worker.py b/vllm/worker/worker.py
+--- a/vllm/worker/worker.py
++++ b/vllm/worker/worker.py
+@@ -24,7 +24,6 @@
+ from vllm.prompt_adapter.request import PromptAdapterRequest
+ from vllm.sequence import (ExecuteModelRequest, IntermediateTensors,
+                            SequenceGroupMetadata, SequenceGroupMetadataDelta)
+-from vllm.utils import rpd_trace
+ from vllm.worker.cache_engine import CacheEngine
+ from vllm.worker.embedding_model_runner import EmbeddingModelRunner
+ from vllm.worker.enc_dec_model_runner import EncoderDecoderModelRunner
+@@ -144,6 +143,8 @@
+             logger.info("Profiling enabled. Traces will be saved to: %s",
+                         rpd_profiler_trace_dir)
+ 
++            from vllm.utils import rpd_trace
++
+             if self.rank == 0:
+                 rpd_trace.create_file(filename=str(rpd_profiler_trace_dir))
+ 

--- a/overrides/patches/vllm-0.6.2/rocm-ubi9/0006-Add-gradlib-dependency.patch
+++ b/overrides/patches/vllm-0.6.2/rocm-ubi9/0006-Add-gradlib-dependency.patch
@@ -1,0 +1,21 @@
+From 2bf543bed39ac63cd07fa22fe3ead4cc963db4a3 Mon Sep 17 00:00:00 2001
+From: Joseph Groenenboom <jgroenen@redhat.com>
+Date: Fri, 15 Nov 2024 04:22:01 -0500
+Subject: [PATCH 6/6] Add gradlib dependency
+
+---
+ requirements-rocm.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/requirements-rocm.txt b/requirements-rocm.txt
+index cb613264..b62815dd 100644
+--- a/requirements-rocm.txt
++++ b/requirements-rocm.txt
+@@ -9,3 +9,4 @@ peft
+ pytest-asyncio
+ tensorizer>=2.9.0
+ setuptools-scm>=8
++gradlib==0.6.2
+-- 
+2.43.5
+

--- a/overrides/patches/vllm-0.6.2/rocm-ubi9/0007-Add-new-AMD-dependencies-for-the-vLLM-image.patch
+++ b/overrides/patches/vllm-0.6.2/rocm-ubi9/0007-Add-new-AMD-dependencies-for-the-vLLM-image.patch
@@ -1,0 +1,24 @@
+From a75cee0ef9afc5c4de951db682b8ec985f7d9c7a Mon Sep 17 00:00:00 2001
+From: Joseph Groenenboom <jgroenen@redhat.com>
+Date: Tue, 26 Nov 2024 21:51:38 -0500
+Subject: [PATCH 7/7] Add new AMD dependencies for the vLLM image
+
+amdsmi, flash attention and Triton are required by vLLM and should be listed.
+---
+ requirements-rocm.txt | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/requirements-rocm.txt b/requirements-rocm.txt
+index b62815dd..46353423 100644
+--- a/requirements-rocm.txt
++++ b/requirements-rocm.txt
+@@ -10,3 +10,6 @@ pytest-asyncio
+ tensorizer>=2.9.0
+ setuptools-scm>=8
+ gradlib==0.6.2
++amdsmi
++triton
++flash_attn==2.6.3
+-- 
+2.43.5
+

--- a/overrides/patches/vllm-0.6.4.post1/cuda-ubi9/0001-Remove-cmake-build-requirement.patch
+++ b/overrides/patches/vllm-0.6.4.post1/cuda-ubi9/0001-Remove-cmake-build-requirement.patch
@@ -1,0 +1,20 @@
+diff --git a/pyproject.toml b/pyproject.toml
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,7 +1,6 @@
+ [build-system]
+ # Should be mirrored in requirements-build.txt
+ requires = [
+-    "cmake>=3.26",
+     "ninja",
+     "packaging",
+     "setuptools>=61",
+diff --git a/requirements-build.txt b/requirements-build.txt
+--- a/requirements-build.txt
++++ b/requirements-build.txt
+@@ -1,5 +1,4 @@
+ # Should be mirrored in pyproject.toml
+-cmake>=3.26
+ ninja
+ packaging
+ setuptools>=61

--- a/overrides/patches/vllm-0.6.4.post1/cuda-ubi9/0002-Remove-ray-dependency.patch
+++ b/overrides/patches/vllm-0.6.4.post1/cuda-ubi9/0002-Remove-ray-dependency.patch
@@ -1,0 +1,47 @@
+diff --git a/requirements-cuda.txt b/requirements-cuda.txt
+--- a/requirements-cuda.txt
++++ b/requirements-cuda.txt
+@@ -2,7 +2,6 @@
+ -r requirements-common.txt
+ 
+ # Dependencies for NVIDIA GPUs
+-ray >= 2.9
+ nvidia-ml-py >= 12.560.30 # for pynvml package
+ torch == 2.5.1
+ # These must be updated alongside torch
+diff --git a/requirements-rocm.txt b/requirements-rocm.txt
+--- a/requirements-rocm.txt
++++ b/requirements-rocm.txt
+@@ -5,7 +5,6 @@
+ awscli
+ boto3
+ botocore
+-ray >= 2.10.0
+ peft
+ pytest-asyncio
+-tensorizer>=2.9.0
+\ No newline at end of file
++tensorizer>=2.9.0
+diff --git a/requirements-test.in b/requirements-test.in
+--- a/requirements-test.in
++++ b/requirements-test.in
+@@ -13,7 +13,6 @@
+ httpx
+ librosa # required for audio tests
+ peft
+-ray[adag]==2.35
+ sentence-transformers # required for embedding tests
+ soundfile # required for audio tests
+ timm # required for internvl test
+diff --git a/requirements-test.txt b/requirements-test.txt
+--- a/requirements-test.txt
++++ b/requirements-test.txt
+@@ -420,8 +420,6 @@
+     #   ray
+     #   timm
+     #   transformers
+-ray[adag]==2.35.0
+-    # via -r requirements-test.in
+ redis==5.2.0
+     # via tensorizer
+ referencing==0.35.1

--- a/overrides/patches/vllm-0.6.4.post1/cuda-ubi9/0003-Remove-version-munging.patch
+++ b/overrides/patches/vllm-0.6.4.post1/cuda-ubi9/0003-Remove-version-munging.patch
@@ -1,0 +1,17 @@
+diff --git a/setup.py b/setup.py
+--- a/setup.py
++++ b/setup.py
+@@ -387,6 +387,7 @@
+ 
+ 
+ def get_vllm_version() -> str:
++    return "0.6.4.post1"
+     version = get_version(
+         write_to="vllm/_version.py",  # TODO: move this to pyproject.toml
+     )
+diff --git a/vllm/_version.py b/vllm/_version.py
+--- a/vllm/_version.py
++++ b/vllm/_version.py
+@@ -0,0 +1,2 @@
++__version__ = "0.6.4.post1"
++__version_tuple__ = ("0", "6", "4", "post1")

--- a/overrides/patches/vllm-0.6.4.post1/cuda-ubi9/0004-Add-triton-dependency.patch
+++ b/overrides/patches/vllm-0.6.4.post1/cuda-ubi9/0004-Add-triton-dependency.patch
@@ -1,0 +1,17 @@
+diff --git a/requirements-cuda.txt b/requirements-cuda.txt
+--- a/requirements-cuda.txt
++++ b/requirements-cuda.txt
+@@ -6,4 +6,5 @@
+ torch == 2.5.1
+ # These must be updated alongside torch
+ torchvision == 0.20.1 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
++triton == 3.1.0 # See https://github.com/pytorch/pytorch/blob/v2.5.1/.ci/docker/triton_version.txt
+ xformers == 0.0.28.post3; platform_system == 'Linux' and platform_machine == 'x86_64'  # Requires PyTorch 2.5.1
+diff --git a/requirements-rocm.txt b/requirements-rocm.txt
+--- a/requirements-rocm.txt
++++ b/requirements-rocm.txt
+@@ -8,3 +8,4 @@
+ peft
+ pytest-asyncio
+ tensorizer>=2.9.0
++triton == 3.1.0 # See https://github.com/pytorch/pytorch/blob/v2.5.1/.ci/docker/triton_version.txt

--- a/overrides/patches/vllm-0.6.4.post1/cuda-ubi9/0005-stop-cutlass-download.patch
+++ b/overrides/patches/vllm-0.6.4.post1/cuda-ubi9/0005-stop-cutlass-download.patch
@@ -1,0 +1,25 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -217,7 +217,7 @@
+         # So if the GIT_TAG above is updated to a commit hash, GIT_SHALLOW must be set to FALSE
+         GIT_SHALLOW TRUE
+   )
+-  FetchContent_MakeAvailable(cutlass)
++  #FetchContent_MakeAvailable(cutlass)
+ 
+   list(APPEND VLLM_EXT_SRC
+     "csrc/mamba/mamba_ssm/selective_scan_fwd.cu"
+@@ -313,6 +313,12 @@
+   #
+   # Machete kernels
+ 
++  if (DEFINED ENV{CUTLASS_DIR})
++    set(CUTLASS_DIR "$ENV{CUTLASS_DIR}")
++    set(CUTLASS_INCLUDE_DIR "$ENV{CUTLASS_DIR}/include")
++  endif()
++
++
+   # The machete kernels only work on hopper and require CUDA 12.0 or later.
+   # Only build Machete kernels if we are building for something compatible with sm90a
+   cuda_archs_loose_intersection(MACHETE_ARCHS "9.0a" "${CUDA_ARCHS}")

--- a/overrides/patches/vllm-0.6.4.post1/cuda-ubi9/0006-GH-PR11390-Fix-fully-sharded-LoRAs-with-Mixtral.patch
+++ b/overrides/patches/vllm-0.6.4.post1/cuda-ubi9/0006-GH-PR11390-Fix-fully-sharded-LoRAs-with-Mixtral.patch
@@ -1,0 +1,36 @@
+diff --git a/vllm/lora/layers.py b/vllm/lora/layers.py
+--- a/vllm/lora/layers.py
++++ b/vllm/lora/layers.py
+@@ -430,8 +430,9 @@
+                        if self.base_layer.skip_bias_add else None)
+         return output, output_bias
+ 
++    # ReplicatedLinear should always be replaced, regardless of the fully￼
++    # sharded LoRAs setting, because it is, by definition, copied per GPU.
+     @classmethod
+-    @_not_fully_sharded_can_replace
+     def can_replace_layer(
+         cls,
+         source_layer: nn.Module,
+diff --git a/tests/lora/test_mixtral.py b/tests/lora/test_mixtral.py
+--- a/tests/lora/test_mixtral.py
++++ b/tests/lora/test_mixtral.py
+@@ -61,8 +61,9 @@
+ 
+ 
+ @pytest.mark.parametrize("tp_size", [4])
++@pytest.mark.parametrize("fully_shard", [True, False])
+ def test_mixtral_lora_all_target_modules(mixtral_lora_files_all_target_modules,
+-                                         tp_size):
++                                         tp_size, fully_shard):
+     """This LoRA model has all supported Mixtral target modules"""
+ 
+     if torch.cuda.device_count() < tp_size:
+@@ -81,6 +82,7 @@
+         max_loras=4,
+         distributed_executor_backend="ray",
+         tensor_parallel_size=tp_size,
++        fully_sharded_loras=fully_shard,
+         max_lora_rank=32,
+     )
+

--- a/overrides/patches/vllm-0.6.4.post2/gaudi-ubi9/0001-Remove-cmake-build-requirement.patch
+++ b/overrides/patches/vllm-0.6.4.post2/gaudi-ubi9/0001-Remove-cmake-build-requirement.patch
@@ -1,0 +1,20 @@
+diff --git a/pyproject.toml b/pyproject.toml
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,7 +1,6 @@
+ [build-system]
+ # Should be mirrored in requirements-build.txt
+ requires = [
+-    "cmake>=3.26",
+     "ninja",
+     "packaging",
+     "setuptools>=61",
+diff --git a/requirements-build.txt b/requirements-build.txt
+--- a/requirements-build.txt
++++ b/requirements-build.txt
+@@ -1,5 +1,4 @@
+ # Should be mirrored in pyproject.toml
+-cmake>=3.26
+ ninja
+ packaging
+ setuptools>=61

--- a/overrides/patches/vllm-0.6.4.post2/gaudi-ubi9/0002-Remove-ray-dependency.patch
+++ b/overrides/patches/vllm-0.6.4.post2/gaudi-ubi9/0002-Remove-ray-dependency.patch
@@ -1,0 +1,58 @@
+diff --git a/requirements-cuda.txt b/requirements-cuda.txt
+--- a/requirements-cuda.txt
++++ b/requirements-cuda.txt
+@@ -2,7 +2,6 @@
+ -r requirements-common.txt
+ 
+ # Dependencies for NVIDIA GPUs
+-ray >= 2.9
+ nvidia-ml-py >= 12.560.30 # for pynvml package
+ torch == 2.5.1
+ # These must be updated alongside torch
+diff --git a/requirements-hpu.txt b/requirements-hpu.txt
+--- a/requirements-hpu.txt
++++ b/requirements-hpu.txt
+@@ -2,7 +2,6 @@
+ -r requirements-common.txt
+ 
+ # Dependencies for HPU code
+-ray
+ triton
+ pandas
+ tabulate
+diff --git a/requirements-rocm.txt b/requirements-rocm.txt
+--- a/requirements-rocm.txt
++++ b/requirements-rocm.txt
+@@ -5,7 +5,6 @@
+ awscli
+ boto3
+ botocore
+-ray >= 2.10.0
+ peft
+ pytest-asyncio
+-tensorizer>=2.9.0
+\ No newline at end of file
++tensorizer>=2.9.0
+diff --git a/requirements-test.in b/requirements-test.in
+--- a/requirements-test.in
++++ b/requirements-test.in
+@@ -13,7 +13,6 @@
+ httpx
+ librosa # required for audio tests
+ peft
+-ray[adag]==2.35
+ sentence-transformers # required for embedding tests
+ soundfile # required for audio tests
+ timm # required for internvl test
+diff --git a/requirements-test.txt b/requirements-test.txt
+--- a/requirements-test.txt
++++ b/requirements-test.txt
+@@ -420,8 +420,6 @@
+     #   ray
+     #   timm
+     #   transformers
+-ray[adag]==2.35.0
+-    # via -r requirements-test.in
+ redis==5.2.0
+     # via tensorizer
+ referencing==0.35.1

--- a/overrides/patches/vllm-0.6.4.post2/gaudi-ubi9/0003-Remove-version-munging.patch
+++ b/overrides/patches/vllm-0.6.4.post2/gaudi-ubi9/0003-Remove-version-munging.patch
@@ -1,0 +1,17 @@
+diff --git a/setup.py b/setup.py
+--- a/setup.py
++++ b/setup.py
+@@ -387,6 +387,7 @@
+ 
+ 
+ def get_vllm_version() -> str:
++    return "0.6.4.post2"
+     version = get_version(
+         write_to="vllm/_version.py",  # TODO: move this to pyproject.toml
+     )
+diff --git a/vllm/_version.py b/vllm/_version.py
+--- a/vllm/_version.py
++++ b/vllm/_version.py
+@@ -0,0 +1,2 @@
++__version__ = "0.6.4.post2"
++__version_tuple__ = ("0", "6", "4", "post2")

--- a/overrides/patches/vllm-0.6.4.post2/gaudi-ubi9/0004-Add-triton-dependency.patch
+++ b/overrides/patches/vllm-0.6.4.post2/gaudi-ubi9/0004-Add-triton-dependency.patch
@@ -1,0 +1,17 @@
+diff --git a/requirements-cuda.txt b/requirements-cuda.txt
+--- a/requirements-cuda.txt
++++ b/requirements-cuda.txt
+@@ -6,4 +6,5 @@
+ torch == 2.5.1
+ # These must be updated alongside torch
+ torchvision == 0.20.1 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
++triton == 3.1.0 # See https://github.com/pytorch/pytorch/blob/v2.5.1/.ci/docker/triton_version.txt
+ xformers == 0.0.28.post3; platform_system == 'Linux' and platform_machine == 'x86_64'  # Requires PyTorch 2.5.1
+diff --git a/requirements-rocm.txt b/requirements-rocm.txt
+--- a/requirements-rocm.txt
++++ b/requirements-rocm.txt
+@@ -8,3 +8,4 @@
+ peft
+ pytest-asyncio
+ tensorizer>=2.9.0
++triton == 3.1.0 # See https://github.com/pytorch/pytorch/blob/v2.5.1/.ci/docker/triton_version.txt

--- a/overrides/patches/vllm-0.6.4.post2/gaudi-ubi9/0005-Relax-Torch-2.5.1.patch
+++ b/overrides/patches/vllm-0.6.4.post2/gaudi-ubi9/0005-Relax-Torch-2.5.1.patch
@@ -1,0 +1,47 @@
+diff --git a/pyproject.toml b/pyproject.toml
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -5,7 +5,7 @@
+     "packaging",
+     "setuptools>=61",
+     "setuptools-scm>=8.0",
+-    "torch == 2.5.1",
++    "torch == 2.5.1a0+git6fc067b",
+     "wheel",
+     "jinja2",
+ ]
+diff --git a/requirements-build.txt b/requirements-build.txt
+--- a/requirements-build.txt
++++ b/requirements-build.txt
+@@ -3,6 +3,6 @@
+ packaging
+ setuptools>=61
+ setuptools-scm>=8
+-torch==2.5.1
++torch~=2.5.1a0+git6fc067b
+ wheel
+ jinja2
+diff --git a/requirements-test.in b/requirements-test.in
+--- a/requirements-test.in
++++ b/requirements-test.in
+@@ -16,7 +16,7 @@
+ sentence-transformers # required for embedding tests
+ soundfile # required for audio tests
+ timm # required for internvl test
+-torch==2.5.1
++torch~=2.5.1a0+git6fc067b
+ transformers_stream_generator # required for qwen-vl test
+ matplotlib # required for qwen-vl test
+ mistral_common[opencv] >= 1.4.4 # required for pixtral test
+diff --git a/requirements-test.txt b/requirements-test.txt
+--- a/requirements-test.txt
++++ b/requirements-test.txt
+@@ -522,7 +522,7 @@
+     # via
+     #   black
+     #   pytest
+-torch==2.5.1
++torch==2.5.1a0+git6fc067b
+     # via
+     #   -r requirements-test.in
+     #   accelerate

--- a/overrides/patches/vllm-0.6.4.post2/gaudi-ubi9/0006-GH-PR11390-Fix-fully-sharded-LoRAs-with-Mixtral.patch
+++ b/overrides/patches/vllm-0.6.4.post2/gaudi-ubi9/0006-GH-PR11390-Fix-fully-sharded-LoRAs-with-Mixtral.patch
@@ -1,0 +1,33 @@
+diff --git a/vllm/lora/layers.py b/vllm/lora/layers.py
+--- a/vllm/lora/layers.py
++++ b/vllm/lora/layers.py
+@@ -439,8 +439,9 @@
+                        if self.base_layer.skip_bias_add else None)
+         return output, output_bias
+ 
++    # ReplicatedLinear should always be replaced, regardless of the fully￼
++    # sharded LoRAs setting, because it is, by definition, copied per GPU.
+     @classmethod
+-    @_not_fully_sharded_can_replace
+     def can_replace_layer(
+         cls,
+         source_layer: nn.Module,
+diff --git a/tests/lora/test_mixtral.py b/tests/lora/test_mixtral.py
+--- a/tests/lora/test_mixtral.py
++++ b/tests/lora/test_mixtral.py
+@@ -61,6 +61,7 @@
+ 
+ 
+ @pytest.mark.parametrize("tp_size", [4])
++@pytest.mark.parametrize("fully_shard", [True, False])
+ def test_mixtral_lora_all_target_modules(mixtral_lora_files_all_target_modules,
+                                          tp_size):
+     """This LoRA model has all supported Mixtral target modules"""
+@@ -81,6 +82,7 @@
+         max_loras=4,
+         distributed_executor_backend="ray",
+         tensor_parallel_size=tp_size,
++        fully_sharded_loras=fully_shard,
+         max_lora_rank=32,
+     )
+ 

--- a/overrides/patches/vllm-0.6.4.post2/gaudi-ubi9/0007-GH-Habana-PR559-Add-multiprocessing-HPU-executor.patch
+++ b/overrides/patches/vllm-0.6.4.post2/gaudi-ubi9/0007-GH-Habana-PR559-Add-multiprocessing-HPU-executor.patch
@@ -1,0 +1,104 @@
+diff --git a/vllm/config.py b/vllm/config.py
+--- a/vllm/config.py
++++ b/vllm/config.py
+@@ -989,13 +989,6 @@
+                 raise ValueError(
+                     "TPU backend only supports Ray for distributed inference.")
+ 
+-        if current_platform.is_hpu() and self.world_size > 1:
+-            if self.distributed_executor_backend is None:
+-                self.distributed_executor_backend = "ray"
+-            if self.distributed_executor_backend != "ray":
+-                raise ValueError(
+-                    "HPU backend only supports Ray for distributed inference.")
+-
+         if self.distributed_executor_backend is None and self.world_size > 1:
+             # We use multiprocessing by default if world_size fits on the
+             # current node and we aren't in a ray placement group.
+diff --git a/vllm/engine/async_llm_engine.py b/vllm/engine/async_llm_engine.py
+--- a/vllm/engine/async_llm_engine.py
++++ b/vllm/engine/async_llm_engine.py
+@@ -630,7 +630,11 @@
+             from vllm.executor.cpu_executor import CPUExecutorAsync
+             executor_class = CPUExecutorAsync
+         elif engine_config.device_config.device_type == "hpu":
+-            if distributed_executor_backend == "ray":
++            if distributed_executor_backend == "mp":
++                from vllm.executor.multiproc_hpu_executor import (
++                    MultiprocessingHPUExecutorAsync)
++                executor_class = MultiprocessingHPUExecutorAsync
++            elif distributed_executor_backend == "ray":
+                 initialize_ray_cluster(engine_config.parallel_config)
+                 from vllm.executor.ray_hpu_executor import RayHPUExecutorAsync
+                 executor_class = RayHPUExecutorAsync
+diff --git a/vllm/engine/llm_engine.py b/vllm/engine/llm_engine.py
+--- a/vllm/engine/llm_engine.py
++++ b/vllm/engine/llm_engine.py
+@@ -529,7 +529,11 @@
+             from vllm.executor.cpu_executor import CPUExecutor
+             executor_class = CPUExecutor
+         elif engine_config.device_config.device_type == "hpu":
+-            if distributed_executor_backend == "ray":
++            if distributed_executor_backend == "mp":
++                from vllm.executor.multiproc_hpu_executor import (
++                    MultiprocessingHPUExecutor)
++                executor_class = MultiprocessingHPUExecutor
++            elif distributed_executor_backend == "ray":
+                 initialize_ray_cluster(engine_config.parallel_config)
+                 from vllm.executor.ray_hpu_executor import RayHPUExecutor
+                 executor_class = RayHPUExecutor
+diff --git a/vllm/executor/multiproc_hpu_executor.py b/vllm/executor/multiproc_hpu_executor.py
+--- a/vllm/executor/multiproc_hpu_executor.py
++++ b/vllm/executor/multiproc_hpu_executor.py
+@@ -0,0 +1,51 @@
++from typing import Callable, Optional, Tuple, Type
++
++import habana_frameworks.torch  # noqa: F401
++import torch
++
++from vllm.executor.multiproc_gpu_executor import (
++    MultiprocessingGPUExecutor, MultiprocessingGPUExecutorAsync)
++from vllm.logger import init_logger
++from vllm.utils import make_async
++from vllm.worker.worker_base import WorkerBase
++
++logger = init_logger(__name__)
++
++
++class MultiprocessingHPUExecutor(MultiprocessingGPUExecutor):
++    """Python multiprocessing-based multi-HPU executor"""
++
++    def _get_worker_module_and_class(
++            self) -> Tuple[str, str, Optional[Callable[[], Type[WorkerBase]]]]:
++        worker_class_fn = None
++        if self.scheduler_config.is_multi_step:
++            module_name = "vllm.worker.multi_step_hpu_worker"
++            class_name = "MultiStepHPUWorker"
++        elif self.speculative_config is not None:
++            module_name = "vllm.spec_decode.spec_decode_worker"
++            class_name = "create_spec_worker"
++        else:
++            module_name = "vllm.worker.hpu_worker"
++            class_name = "HPUWorker"
++        return (module_name, class_name, worker_class_fn)
++
++    def _check_executor_parameters(self):
++        world_size = self.parallel_config.world_size
++        tensor_parallel_size = self.parallel_config.tensor_parallel_size
++
++        hpu_device_count = torch.hpu.device_count()
++        assert tensor_parallel_size <= hpu_device_count, (
++            f"please set tensor_parallel_size ({tensor_parallel_size}) "
++            f"to less than max local hpu count ({hpu_device_count})")
++
++        assert world_size <= hpu_device_count, (
++            f"please ensure that world_size ({world_size}) "
++            f"is less than than max local hpu count ({hpu_device_count})")
++
++
++class MultiprocessingHPUExecutorAsync(MultiprocessingHPUExecutor,
++                                      MultiprocessingGPUExecutorAsync):
++
++    def __init__(self, *args, **kwargs):
++        super().__init__(*args, **kwargs)
++        self.driver_exec_model = make_async(self.driver_worker.execute_model)

--- a/overrides/patches/xformers-0.0.27/002-set-fixed-versions-for-requirements.patch
+++ b/overrides/patches/xformers-0.0.27/002-set-fixed-versions-for-requirements.patch
@@ -1,0 +1,8 @@
+--- xformers-0.0.27.orig/requirements.txt	2024-07-22 10:55:17.999486569 -0400
++++ xformers-0.0.27/requirements.txt	2024-07-22 10:58:08.753024616 -0400
+@@ -1,4 +1,4 @@
+ # Example requirement, can be anything that pip knows
+ # install with `pip install -r requirements.txt`, and make sure that CI does the same
+ torch >= 2.2
+-numpy
++numpy < 2.0

--- a/overrides/patches/xformers-0.0.28.post3/0001-set-fixed-versions-for-requirements.patch
+++ b/overrides/patches/xformers-0.0.28.post3/0001-set-fixed-versions-for-requirements.patch
@@ -1,0 +1,10 @@
+diff --git a/requirements.txt b/requirements.txt
+--- a/requirements.txt
++++ b/requirements.txt
+@@ -1,4 +2,4 @@
+ # Example requirement, can be anything that pip knows
+ # install with `pip install -r requirements.txt`, and make sure that CI does the same
+ torch >= 2.4
+-numpy
++numpy < 2.0.0
++einops

--- a/overrides/patches/xformers-0.0.28.post3/0002-use-external-flash_attn-source.patch
+++ b/overrides/patches/xformers-0.0.28.post3/0002-use-external-flash_attn-source.patch
@@ -1,0 +1,70 @@
+diff --git a/setup.py b/setup.py
+--- a/setup.py
++++ b/setup.py
+@@ -218,6 +218,10 @@
+ 
+     flash_root = os.path.join(this_dir, "third_party", "flash-attention")
+     cutlass_inc = os.path.join(flash_root, "csrc", "cutlass", "include")
++    # Allow overriding flash_attn source dir with environement variable
++    flash_external_root = os.environ.get('FLASH_ATTENTION_SOURCE_DIR', '')
++    if flash_external_root != '':
++        flash_root = flash_external_root
+     if not os.path.exists(flash_root) or not os.path.exists(cutlass_inc):
+         raise RuntimeError(
+             "flashattention submodule not found. Did you forget "
+@@ -258,7 +262,7 @@
+                 for p in [
+                     Path(flash_root) / "csrc" / "flash_attn",
+                     Path(flash_root) / "csrc" / "flash_attn" / "src",
+-                    Path(flash_root) / "csrc" / "cutlass" / "include",
++                    Path(cutlass_inc),
+                 ]
+             ],
+         )
+@@ -304,6 +308,10 @@
+ 
+     flash_root = os.path.join(this_dir, "third_party", "flash-attention")
+     cutlass_inc = os.path.join(flash_root, "csrc", "cutlass", "include")
++    # Allow overriding flash_attn source dir with environement variable
++    flash_external_root = os.environ.get('FLASH_ATTENTION_SOURCE_DIR', '')
++    if flash_external_root != '':
++        flash_root = flash_external_root
+     if not os.path.exists(flash_root) or not os.path.exists(cutlass_inc):
+         raise RuntimeError(
+             "flashattention submodule not found. Did you forget "
+@@ -352,7 +360,7 @@
+             include_dirs=[
+                 p.absolute()
+                 for p in [
+-                    Path(flash_root) / "csrc" / "cutlass" / "include",
++                    Path(cutlass_inc),
+                     Path(flash_root) / "hopper",
+                 ]
+             ],
+@@ -671,11 +679,21 @@
+     # parameter in `setuptools.setup`, but this does not work when
+     # developing in editable mode
+     # See: https://github.com/pypa/pip/issues/3160 (closed, but not fixed)
+-    symlink_package(
+-        "xformers._flash_attn",
+-        Path("third_party") / "flash-attention" / "flash_attn",
+-        is_building_wheel,
+-    )
++    #
++    # Allow overriding flash_attn source dir with environement variable
++    flash_external_root = os.environ.get('FLASH_ATTENTION_SOURCE_DIR', '')
++    if flash_external_root != '':
++        symlink_package(
++            "xformers._flash_attn",
++            Path(flash_external_root) / "flash_attn",
++            is_building_wheel,
++        )
++    else:
++        symlink_package(
++            "xformers._flash_attn",
++            Path("third_party") / "flash-attention" / "flash_attn",
++            is_building_wheel,
++        )
+     extensions, extensions_metadata = get_extensions()
+     setuptools.setup(
+         name="xformers",


### PR DESCRIPTION
These patches are used as part of building the components of RHEL AI
1.4. There is a combination of fixes, changes to make components build
using RHEL tools instead of wheel versions of those tools, and changes
to ensure builds can run without network access.